### PR TITLE
Fix token generation length to exactly 32 characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Some environment variables in the `.env` file have a default value of `changethi
 You have to change them with a secret key, to generate secret keys you can run the following command:
 
 ```bash
-python -c "import secrets; print(secrets.token_urlsafe(32))"
+python -c "import secrets; print(secrets.token_urlsafe(32)[:32])"
 ```
 
 Copy the content and use that as password / secret key. And run that again to generate another secure key.


### PR DESCRIPTION
Modified `secrets.token_urlsafe(32)` to include `[:32]` slice to ensure consistent 32-character token output. The original implementation generated 32 bytes of random data which, after base64 encoding, resulted in 43 characters. This fix standardizes our token length while maintaining security