### PR TITLE
Display Tag Information with Corresponding TagType

### DIFF
--- a/backend/app/api/routes/question.py
+++ b/backend/app/api/routes/question.py
@@ -41,7 +41,7 @@ def get_tag_type_by_id(session: SessionDep, tag_type_id: int) -> TagType:
     """Helper function to get TagType by ID."""
     tag_type = session.get(TagType, tag_type_id)
     if not tag_type or tag_type.is_deleted:
-        raise HTTPException(status_code=404, detail="Tag Type not found")
+        return None
     return tag_type
 
 
@@ -73,13 +73,13 @@ def build_question_response(
     )
 
     # Prepare tag information
-    tag_list = []
+    tag_list: list[TagPublic] = []
     if tags:
         tag_list = [
             TagPublic(
                 id=tag.id,
                 name=tag.name,
-                tag_type=get_tag_type_by_id(session, tag_type_id=tag.tag_type_id),
+                tag_type=tag_type,
                 description=tag.description,
                 created_by_id=tag.created_by_id,
                 organization_id=tag.organization_id,
@@ -89,6 +89,7 @@ def build_question_response(
                 is_deleted=tag.is_deleted,
             )
             for tag in tags
+            if (tag_type := get_tag_type_by_id(session, tag_type_id=tag.tag_type_id))
         ]
 
     # Prepare location information
@@ -901,7 +902,7 @@ def get_question_tags(question_id: int, session: SessionDep) -> list[TagPublic]:
         TagPublic(
             id=tag.id,
             name=tag.name,
-            tag_type=get_tag_type_by_id(session, tag_type_id=tag.tag_type_id),
+            tag_type=tag_type,
             description=tag.description,
             created_by_id=tag.created_by_id,
             organization_id=tag.organization_id,
@@ -911,6 +912,7 @@ def get_question_tags(question_id: int, session: SessionDep) -> list[TagPublic]:
             is_deleted=tag.is_deleted,
         )
         for tag in tags
+        if (tag_type := get_tag_type_by_id(session, tag_type_id=tag.tag_type_id))
     ]
 
     return result

--- a/backend/app/api/routes/question.py
+++ b/backend/app/api/routes/question.py
@@ -70,7 +70,7 @@ def build_question_response(
             TagPublic(
                 id=tag.id,
                 name=tag.name,
-                tag_type_id=tag.tag_type_id,
+                tag_type=TagType(id=tag.tag_type_id),
                 description=tag.description,
                 created_by_id=tag.created_by_id,
                 organization_id=tag.organization_id,
@@ -890,7 +890,7 @@ def get_question_tags(question_id: int, session: SessionDep) -> list[TagPublic]:
         TagPublic(
             id=tag.id,
             name=tag.name,
-            tag_type_id=tag.tag_type_id,
+            tag_type=TagType(id=tag.tag_type_id),
             description=tag.description,
             created_by_id=tag.created_by_id,
             organization_id=tag.organization_id,

--- a/backend/app/api/routes/question.py
+++ b/backend/app/api/routes/question.py
@@ -37,7 +37,16 @@ from app.models import (
 router = APIRouter(prefix="/questions", tags=["Questions"])
 
 
+def get_tag_type_by_id(session: SessionDep, tag_type_id: int) -> TagType:
+    """Helper function to get TagType by ID."""
+    tag_type = session.get(TagType, tag_type_id)
+    if not tag_type or tag_type.is_deleted:
+        raise HTTPException(status_code=404, detail="Tag Type not found")
+    return tag_type
+
+
 def build_question_response(
+    session: SessionDep,
     question: Question,
     revision: QuestionRevision,
     locations: list[QuestionLocation],
@@ -70,7 +79,7 @@ def build_question_response(
             TagPublic(
                 id=tag.id,
                 name=tag.name,
-                tag_type=TagType(id=tag.tag_type_id),
+                tag_type=get_tag_type_by_id(session, tag_type_id=tag.tag_type_id),
                 description=tag.description,
                 created_by_id=tag.created_by_id,
                 organization_id=tag.organization_id,
@@ -246,7 +255,7 @@ def create_question(
     session.commit()
     # No need to set modified_date manually, as SQLModel will handle it via onupdate
 
-    return build_question_response(question, revision, locations, tags)
+    return build_question_response(session, question, revision, locations, tags)
 
 
 # TypedDict classes with all required fields
@@ -408,7 +417,7 @@ def get_questions(
         tags = session.exec(tags_query).all()
 
         question_data = build_question_response(
-            question, latest_revision, list(locations), list(tags)
+            session, question, latest_revision, list(locations), list(tags)
         )
         result.append(question_data)
 
@@ -536,7 +545,7 @@ def get_question_by_id(question_id: int, session: SessionDep) -> QuestionPublic:
     tags = session.exec(tags_query).all()
 
     return build_question_response(
-        question, latest_revision, list(locations), list(tags)
+        session, question, latest_revision, list(locations), list(tags)
     )
 
 
@@ -576,7 +585,7 @@ def update_question(
     tags = session.exec(tags_query).all()
 
     return build_question_response(
-        question, latest_revision, list(locations), list(tags)
+        session, question, latest_revision, list(locations), list(tags)
     )
 
 
@@ -628,7 +637,9 @@ def create_question_revision(
     )
     tags = session.exec(tags_query).all()
 
-    return build_question_response(question, new_revision, list(locations), list(tags))
+    return build_question_response(
+        session, question, new_revision, list(locations), list(tags)
+    )
 
 
 @router.get("/{question_id}/revisions", response_model=list[QuestionRevisionInfo])
@@ -890,7 +901,7 @@ def get_question_tags(question_id: int, session: SessionDep) -> list[TagPublic]:
         TagPublic(
             id=tag.id,
             name=tag.name,
-            tag_type=TagType(id=tag.tag_type_id),
+            tag_type=get_tag_type_by_id(session, tag_type_id=tag.tag_type_id),
             description=tag.description,
             created_by_id=tag.created_by_id,
             organization_id=tag.organization_id,

--- a/backend/app/api/routes/question.py
+++ b/backend/app/api/routes/question.py
@@ -37,7 +37,7 @@ from app.models import (
 router = APIRouter(prefix="/questions", tags=["Questions"])
 
 
-def get_tag_type_by_id(session: SessionDep, tag_type_id: int) -> TagType:
+def get_tag_type_by_id(session: SessionDep, tag_type_id: int) -> TagType | None:
     """Helper function to get TagType by ID."""
     tag_type = session.get(TagType, tag_type_id)
     if not tag_type or tag_type.is_deleted:

--- a/backend/app/api/routes/tag.py
+++ b/backend/app/api/routes/tag.py
@@ -117,14 +117,23 @@ def create_tag(tag_create: TagCreate, session: SessionDep) -> Tag:
     session.add(tag)
     session.commit()
     session.refresh(tag)
-    return tag
+    session.refresh(tag_type)
+
+    return TagPublic(**tag.model_dump(), tag_type=tag_type)
 
 
 # Get all Tags
 @router_tag.get("/", response_model=list[TagPublic])
 def get_tags(session: SessionDep) -> Sequence[Tag]:
     tags = session.exec(select(Tag).where(not_(Tag.is_deleted))).all()
-    return tags
+    tag_public = []
+    for tag in tags:
+        tag_type = session.get(TagType, tag.tag_type_id)
+        if not tag_type or tag_type.is_deleted is True:
+            continue
+        tag_public.append(TagPublic(**tag.model_dump(), tag_type=tag_type))
+
+    return tag_public
 
 
 # Get Tag by ID
@@ -133,7 +142,10 @@ def get_tag_by_id(tag_id: int, session: SessionDep) -> Tag:
     tag = session.get(Tag, tag_id)
     if not tag or tag.is_deleted is True:
         raise HTTPException(status_code=404, detail="Tag not found")
-    return tag
+    tag_type = session.get(TagType, tag.tag_type_id)
+    if not tag_type or tag_type.is_deleted is True:
+        raise HTTPException(status_code=404, detail="Tag Type not found")
+    return TagPublic(**tag.model_dump(), tag_type=tag_type)
 
 
 # Update a Tag
@@ -151,7 +163,11 @@ def update_tag(
     session.add(tag)
     session.commit()
     session.refresh(tag)
-    return tag
+    tag_type = session.get(TagType, tag.tag_type_id)
+    if not tag_type or tag_type.is_deleted is True:
+        raise HTTPException(status_code=404, detail="Tag Type not found")
+
+    return TagPublic(**tag.model_dump(), tag_type=tag_type)
 
 
 # Set visibility of Tag
@@ -170,7 +186,11 @@ def visibility_tag(
     session.add(tag)
     session.commit()
     session.refresh(tag)
-    return tag
+    tag_type = session.get(TagType, tag.tag_type_id)
+    if not tag_type or tag_type.is_deleted is True:
+        raise HTTPException(status_code=404, detail="Tag Type not found")
+
+    return TagPublic(**tag.model_dump(), tag_type=tag_type)
 
 
 # Delete a Tag

--- a/backend/app/api/routes/tag.py
+++ b/backend/app/api/routes/tag.py
@@ -119,7 +119,7 @@ def create_tag(tag_create: TagCreate, session: SessionDep) -> TagPublic:
     session.refresh(tag)
     session.refresh(tag_type)
 
-    return TagPublic(**tag.model_dump(), tag_type=tag_type)
+    return TagPublic(**tag.model_dump(exclude={"tag_type_id"}), tag_type=tag_type)
 
 
 # Get all Tags
@@ -131,7 +131,9 @@ def get_tags(session: SessionDep) -> Sequence[TagPublic]:
         tag_type = session.get(TagType, tag.tag_type_id)
         if not tag_type or tag_type.is_deleted is True:
             continue
-        tag_public.append(TagPublic(**tag.model_dump(), tag_type=tag_type))
+        tag_public.append(
+            TagPublic(**tag.model_dump(exclude={"tag_type_id"}), tag_type=tag_type)
+        )
 
     return tag_public
 
@@ -145,7 +147,7 @@ def get_tag_by_id(tag_id: int, session: SessionDep) -> TagPublic:
     tag_type = session.get(TagType, tag.tag_type_id)
     if not tag_type or tag_type.is_deleted is True:
         raise HTTPException(status_code=404, detail="Tag Type not found")
-    return TagPublic(**tag.model_dump(), tag_type=tag_type)
+    return TagPublic(**tag.model_dump(exclude={"tag_type_id"}), tag_type=tag_type)
 
 
 # Update a Tag
@@ -167,7 +169,7 @@ def update_tag(
     if not tag_type or tag_type.is_deleted is True:
         raise HTTPException(status_code=404, detail="Tag Type not found")
 
-    return TagPublic(**tag.model_dump(), tag_type=tag_type)
+    return TagPublic(**tag.model_dump(exclude={"tag_type_id"}), tag_type=tag_type)
 
 
 # Set visibility of Tag
@@ -190,7 +192,7 @@ def visibility_tag(
     if not tag_type or tag_type.is_deleted is True:
         raise HTTPException(status_code=404, detail="Tag Type not found")
 
-    return TagPublic(**tag.model_dump(), tag_type=tag_type)
+    return TagPublic(**tag.model_dump(exclude={"tag_type_id"}), tag_type=tag_type)
 
 
 # Delete a Tag

--- a/backend/app/api/routes/tag.py
+++ b/backend/app/api/routes/tag.py
@@ -104,7 +104,7 @@ def delete_tagtype(tagtype_id: int, session: SessionDep) -> Message:
 
 # Create a Tag
 @router_tag.post("/", response_model=TagPublic)
-def create_tag(tag_create: TagCreate, session: SessionDep) -> Tag:
+def create_tag(tag_create: TagCreate, session: SessionDep) -> TagPublic:
     tag_type_id = tag_create.tag_type_id
     tag_type = session.get(TagType, tag_type_id)
     if not tag_type or tag_type.is_deleted is True:
@@ -124,7 +124,7 @@ def create_tag(tag_create: TagCreate, session: SessionDep) -> Tag:
 
 # Get all Tags
 @router_tag.get("/", response_model=list[TagPublic])
-def get_tags(session: SessionDep) -> Sequence[Tag]:
+def get_tags(session: SessionDep) -> Sequence[TagPublic]:
     tags = session.exec(select(Tag).where(not_(Tag.is_deleted))).all()
     tag_public = []
     for tag in tags:
@@ -138,7 +138,7 @@ def get_tags(session: SessionDep) -> Sequence[Tag]:
 
 # Get Tag by ID
 @router_tag.get("/{tag_id}", response_model=TagPublic)
-def get_tag_by_id(tag_id: int, session: SessionDep) -> Tag:
+def get_tag_by_id(tag_id: int, session: SessionDep) -> TagPublic:
     tag = session.get(Tag, tag_id)
     if not tag or tag.is_deleted is True:
         raise HTTPException(status_code=404, detail="Tag not found")
@@ -154,7 +154,7 @@ def update_tag(
     tag_id: int,
     updated_data: TagUpdate,
     session: SessionDep,
-) -> Tag:
+) -> TagPublic:
     tag = session.get(Tag, tag_id)
     if not tag or tag.is_deleted is True:
         raise HTTPException(status_code=404, detail="Tag not found")
@@ -178,7 +178,7 @@ def visibility_tag(
     tag_id: int,
     session: SessionDep,
     is_active: bool = Query(False, description="Set visibility of Tag"),
-) -> Tag:
+) -> TagPublic:
     tag = session.get(Tag, tag_id)
     if not tag or tag.is_deleted is True:
         raise HTTPException(status_code=404, detail="Tag not found")

--- a/backend/app/models/tag.py
+++ b/backend/app/models/tag.py
@@ -61,11 +61,6 @@ class TagTypeUpdate(TagTypeBase):
 
 
 class TagBase(SQLModel):
-    tag_type_id: int = Field(
-        foreign_key="tagtype.id",
-        nullable=False,
-        description="ID of the Tag Type to which the Tag should belong to",
-    )
     name: str = Field(nullable=False, index=True, description="Name of the Tag")
     description: str | None = Field(
         default=None, nullable=True, description="Description of the Tag"
@@ -86,6 +81,11 @@ class Tag(TagBase, table=True):
         default_factory=lambda: datetime.now(timezone.utc),
         sa_column_kwargs={"onupdate": datetime.now(timezone.utc)},
     )
+    tag_type_id: int = Field(
+        foreign_key="tagtype.id",
+        nullable=False,
+        description="ID of the Tag Type to which the Tag should belong to",
+    )
     is_active: bool | None = Field(default=None, nullable=True)
     is_deleted: bool = Field(default=False, nullable=False)
     tag_type: "TagType" = Relationship(back_populates="tags")
@@ -103,7 +103,7 @@ class Tag(TagBase, table=True):
 
 
 class TagCreate(TagBase):
-    pass
+    tag_type_id: int
 
 
 class TagPublic(TagBase):
@@ -112,13 +112,13 @@ class TagPublic(TagBase):
     modified_date: datetime
     is_active: bool | None
     is_deleted: bool
-    tag_type_id: int
+    tag_type: TagType
     organization_id: int
     created_by_id: int
 
 
 class TagUpdate(TagBase):
-    pass
+    tag_type_id: int
 
 
 # Rebuild the models to ensure the database schema is up to date

--- a/backend/app/tests/api/routes/test_tag.py
+++ b/backend/app/tests/api/routes/test_tag.py
@@ -344,6 +344,25 @@ def test_create_tag(
     assert "created_date" in response_data
     assert "modified_date" in response_data
 
+    response = client.delete(
+        f"{settings.API_V1_STR}/tagtype/{tagtype.id}",
+        headers=get_user_superadmin_token,
+    )
+
+    response_data = response.json()
+    print(response_data)
+    assert response.status_code == 200
+    assert "delete" in response_data["message"]
+
+    response = client.post(
+        f"{settings.API_V1_STR}/tag/",
+        json=data,
+        headers=get_user_superadmin_token,
+    )
+    response_data = response.json()
+    assert response.status_code == 404
+    assert "not found" in response_data["detail"]
+
 
 def test_read_tag(
     client: TestClient,
@@ -385,6 +404,7 @@ def test_read_tag(
         headers=get_user_superadmin_token,
     )
     response_data = response.json()
+    print("Response Data:", response_data)
     assert response.status_code == 200
     assert any(item["name"] == tag.name for item in response_data)
     assert any(item["description"] == tag.description for item in response_data)
@@ -393,8 +413,44 @@ def test_read_tag(
     assert any(item["created_by_id"] == tag.created_by_id for item in response_data)
     assert any(item["is_deleted"] == tag.is_deleted for item in response_data)
 
-    assert "created_date" in response_data[1]
-    assert "modified_date" in response_data[1]
+    assert any(item["created_date"] for item in response_data)
+    assert any(item["modified_date"] for item in response_data)
+
+    tagtype_2 = TagType(
+        name=random_lower_string(),
+        description=random_lower_string(),
+        organization_id=organization.id,
+        created_by_id=user.id,
+    )
+    db.add(tagtype_2)
+    db.commit()
+    tag_2 = Tag(
+        name=random_lower_string(),
+        description=random_lower_string(),
+        tag_type_id=tagtype_2.id,
+        created_by_id=user.id,
+        organization_id=organization.id,
+    )
+    db.add(tag_2)
+    db.commit()
+    db.refresh(tag_2)
+    db.flush()
+
+    response = client.delete(
+        f"{settings.API_V1_STR}/tagtype/{tagtype_2.id}",
+        headers=get_user_superadmin_token,
+    )
+    response_data = response.json()
+    assert response.status_code == 200
+    assert "delete" in response_data["message"]
+    response = client.get(
+        f"{settings.API_V1_STR}/tag/",
+        headers=get_user_superadmin_token,
+    )
+    response_data = response.json()
+    print("Complete Response Data:", response_data)
+    assert any(item["name"] != tag_2.name for item in response_data)
+    assert any(item["description"] != tag_2.description for item in response_data)
 
 
 def test_read_tag_by_id(
@@ -439,6 +495,30 @@ def test_read_tag_by_id(
     assert response_data["is_deleted"] is False
     assert "created_date" in response_data
     assert "modified_date" in response_data
+
+    response = client.get(
+        f"{settings.API_V1_STR}/tag/-1",
+        headers=get_user_superadmin_token,
+    )
+    response_data = response.json()
+    assert response.status_code == 404
+    assert response_data["detail"] == "Tag not found"
+
+    response = client.delete(
+        f"{settings.API_V1_STR}/tagtype/{tagtype.id}",
+        headers=get_user_superadmin_token,
+    )
+    response_data = response.json()
+    assert response.status_code == 200
+    assert "delete" in response_data["message"]
+
+    response = client.get(
+        f"{settings.API_V1_STR}/tag/{tag.id}",
+        headers=get_user_superadmin_token,
+    )
+    response_data = response.json()
+    assert response.status_code == 404
+    assert "not found" in response_data["detail"]
 
 
 def test_update_tag_by_id(
@@ -578,6 +658,15 @@ def test_visibility_tag_by_id(
     assert response_data["tag_type"]["description"] == tag.tag_type.description
     assert response_data["organization_id"] == tagtype.organization_id
     assert response_data["created_by_id"] == user_b.id
+
+    response = client.patch(
+        f"{settings.API_V1_STR}/tag/-1",
+        params={"is_active": True},
+        headers=get_user_superadmin_token,
+    )
+    response_data = response.json()
+    assert response.status_code == 404
+    assert "not found" in response_data["detail"]
 
 
 def test_delete_tag_by_id(

--- a/backend/app/tests/api/routes/test_tag.py
+++ b/backend/app/tests/api/routes/test_tag.py
@@ -413,8 +413,8 @@ def test_read_tag(
     assert any(item["created_by_id"] == tag.created_by_id for item in response_data)
     assert any(item["is_deleted"] == tag.is_deleted for item in response_data)
 
-    assert any(item["created_date"] for item in response_data)
-    assert any(item["modified_date"] for item in response_data)
+    assert all(item["created_date"] for item in response_data)
+    assert all(item["modified_date"] for item in response_data)
 
     tagtype_2 = TagType(
         name=random_lower_string(),

--- a/backend/app/tests/api/routes/test_tag.py
+++ b/backend/app/tests/api/routes/test_tag.py
@@ -449,8 +449,8 @@ def test_read_tag(
     )
     response_data = response.json()
     print("Complete Response Data:", response_data)
-    assert any(item["name"] != tag_2.name for item in response_data)
-    assert any(item["description"] != tag_2.description for item in response_data)
+    assert all(item["name"] != tag_2.name for item in response_data)
+    assert all(item["description"] != tag_2.description for item in response_data)
 
 
 def test_read_tag_by_id(
@@ -662,6 +662,23 @@ def test_visibility_tag_by_id(
     response = client.patch(
         f"{settings.API_V1_STR}/tag/-1",
         params={"is_active": True},
+        headers=get_user_superadmin_token,
+    )
+    response_data = response.json()
+    assert response.status_code == 404
+    assert "not found" in response_data["detail"]
+
+    response = client.delete(
+        f"{settings.API_V1_STR}/tagtype/{tagtype.id}",
+        headers=get_user_superadmin_token,
+    )
+    response_data = response.json()
+    assert response.status_code == 200
+    assert "delete" in response_data["message"]
+
+    response = client.patch(
+        f"{settings.API_V1_STR}/tag/{tag.id}",
+        json={"is_active": False},
         headers=get_user_superadmin_token,
     )
     response_data = response.json()

--- a/backend/app/tests/api/routes/test_tag.py
+++ b/backend/app/tests/api/routes/test_tag.py
@@ -309,7 +309,11 @@ def test_create_tag(
     assert response.status_code == 200
     assert response_data["name"] == data["name"]
     assert response_data["description"] == data["description"]
-    assert response_data["tag_type_id"] == data["tag_type_id"]
+    assert response_data["tag_type"]["name"] == tagtype.name
+    assert response_data["tag_type"]["id"] == tagtype.id
+    assert response_data["tag_type"]["description"] == tagtype.description
+    assert response_data["tag_type"]["organization_id"] == tagtype.organization_id
+    assert response_data["tag_type"]["created_by_id"] == tagtype.created_by_id
     assert response_data["organization_id"] == tagtype.organization_id
     assert response_data["is_deleted"] is False
     assert "created_date" in response_data
@@ -329,7 +333,12 @@ def test_create_tag(
     assert response.status_code == 200
     assert response_data["name"] == data["name"]
     assert response_data["description"] is None
-    assert response_data["tag_type_id"] == data["tag_type_id"]
+
+    assert response_data["tag_type"]["id"] == tagtype.id
+    assert response_data["tag_type"]["description"] == tagtype.description
+    assert response_data["tag_type"]["organization_id"] == tagtype.organization_id
+    assert response_data["tag_type"]["created_by_id"] == tagtype.created_by_id
+
     assert response_data["organization_id"] == tagtype.organization_id
     assert response_data["is_deleted"] is False
     assert "created_date" in response_data
@@ -379,7 +388,7 @@ def test_read_tag(
     assert response.status_code == 200
     assert any(item["name"] == tag.name for item in response_data)
     assert any(item["description"] == tag.description for item in response_data)
-    assert any(item["tag_type_id"] == tag.tag_type_id for item in response_data)
+    assert any(item["tag_type"]["id"] == tag.tag_type.id for item in response_data)
     assert any(item["organization_id"] == tag.organization_id for item in response_data)
     assert any(item["created_by_id"] == tag.created_by_id for item in response_data)
     assert any(item["is_deleted"] == tag.is_deleted for item in response_data)
@@ -422,7 +431,9 @@ def test_read_tag_by_id(
     assert response.status_code == 200
     assert response_data["name"] == tag.name
     assert response_data["description"] == tag.description
-    assert response_data["tag_type_id"] == tag.tag_type_id
+    assert response_data["tag_type"]["id"] == tag.tag_type.id
+    assert response_data["tag_type"]["name"] == tag.tag_type.name
+    assert response_data["tag_type"]["description"] == tag.tag_type.description
     assert response_data["organization_id"] == tagtype.organization_id
     assert response_data["created_by_id"] == user_b.id
     assert response_data["is_deleted"] is False
@@ -480,7 +491,9 @@ def test_update_tag_by_id(
     assert response.status_code == 200
     assert response_data["name"] == data_a["name"]
     assert response_data["description"] == data_a["description"]
-    assert response_data["tag_type_id"] == data_a["tag_type_id"]
+    assert response_data["tag_type"]["id"] == data_a["tag_type_id"]
+    assert response_data["tag_type"]["name"] == tagtype.name
+    assert response_data["tag_type"]["description"] == tagtype.description
     assert response_data["organization_id"] == tagtype.organization_id
     assert response_data["created_by_id"] == user_b.id
     assert response_data["is_deleted"] is False
@@ -496,7 +509,7 @@ def test_update_tag_by_id(
     assert response.status_code == 200
     assert response_data["name"] == data_b["name"]
     assert response_data["description"] == data_b["description"]
-    assert response_data["tag_type_id"] == data_b["tag_type_id"]
+    assert response_data["tag_type"]["id"] == data_b["tag_type_id"]
     assert response_data["organization_id"] == tagtype.organization_id
 
 
@@ -541,7 +554,9 @@ def test_visibility_tag_by_id(
     assert "modified_date" in response_data
     assert response_data["name"] == tag.name
     assert response_data["description"] == tag.description
-    assert response_data["tag_type_id"] == tag.tag_type_id
+    assert response_data["tag_type"]["id"] == tag.tag_type.id
+    assert response_data["tag_type"]["name"] == tag.tag_type.name
+    assert response_data["tag_type"]["description"] == tag.tag_type.description
     assert response_data["organization_id"] == tagtype.organization_id
     assert response_data["created_by_id"] == user_b.id
 
@@ -558,7 +573,9 @@ def test_visibility_tag_by_id(
     assert "modified_date" in response_data
     assert response_data["name"] == tag.name
     assert response_data["description"] == tag.description
-    assert response_data["tag_type_id"] == tag.tag_type_id
+    assert response_data["tag_type"]["id"] == tag.tag_type.id
+    assert response_data["tag_type"]["name"] == tag.tag_type.name
+    assert response_data["tag_type"]["description"] == tag.tag_type.description
     assert response_data["organization_id"] == tagtype.organization_id
     assert response_data["created_by_id"] == user_b.id
 


### PR DESCRIPTION
## Summary

Fixes issue: #95

The Public Model of the Tag is updated to show information of its corresponding Tag-Type. This is made so that we can display the type of the tag when it is rendered . Example [ Hard tag - (Difficulty Tag Type)]

## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [ ] If you've fixed a bug or added code that is tested and has test cases.

## Notes

Please add here if any other information is required for the reviewer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Tag-related API responses now include detailed tag type information as nested objects instead of just IDs.

- **Bug Fixes**
  - Enhanced validation to ensure tag types exist and are active when accessing tag data.
  - API endpoints return appropriate errors when associated tag types are deleted or missing.
  - Tags linked to deleted tag types are filtered out from responses.

- **Tests**
  - Updated tests to verify nested tag type details in API responses.
  - Added coverage for behavior when tag types are deleted, including error handling and filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->