### PR TITLE
Create/Update tags and locations in bulk

### DIFF
--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -55,14 +55,14 @@ from .question import (
     QuestionCandidatePublic,
     QuestionCreate,
     QuestionLocation,
-    QuestionLocationItem,
     QuestionLocationPublic,
-    QuestionLocationsCreate,
+    QuestionLocationsUpdate,
+    QuestionLocationUpdateItem,
     QuestionPublic,
     QuestionRevision,
     QuestionRevisionCreate,
     QuestionTag,
-    QuestionTagsCreate,
+    QuestionTagsUpdate,
     QuestionUpdate,
 )
 from .role import Role, RoleCreate, RolePermission, RolePublic, RolesPublic, RoleUpdate
@@ -191,9 +191,9 @@ __all__ = [
     "PermissionsPublic",
     "PermissionUpdate",
     "RolePermission",
-    "QuestionLocationItem",
-    "QuestionLocationsCreate",
-    "QuestionTagsCreate",
+    "QuestionLocationUpdateItem",
+    "QuestionLocationsUpdate",
+    "QuestionTagsUpdate",
 ]
 
 # Rebuild models to resolve forward references after all imports are complete

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -49,17 +49,20 @@ from .permission import (
     PermissionUpdate,
 )
 from .question import (
+    Option,
     Question,
+    QuestionBase,
     QuestionCandidatePublic,
     QuestionCreate,
     QuestionLocation,
-    QuestionLocationCreate,
+    QuestionLocationItem,
     QuestionLocationPublic,
+    QuestionLocationsCreate,
     QuestionPublic,
     QuestionRevision,
     QuestionRevisionCreate,
     QuestionTag,
-    QuestionTagCreate,
+    QuestionTagsCreate,
     QuestionUpdate,
 )
 from .role import Role, RoleCreate, RolePermission, RolePublic, RolesPublic, RoleUpdate
@@ -139,17 +142,17 @@ __all__ = [
     "TestQuestion",
     "TestTag",
     "TestState",
+    "Option",
     "Question",
+    "QuestionBase",
     "QuestionCandidatePublic",
     "QuestionCreate",
     "QuestionLocation",
-    "QuestionLocationCreate",
     "QuestionLocationPublic",
     "QuestionPublic",
     "QuestionRevision",
     "QuestionRevisionCreate",
     "QuestionTag",
-    "QuestionTagCreate",
     "QuestionUpdate",
     "Tag",
     "TagPublic",
@@ -188,6 +191,9 @@ __all__ = [
     "PermissionsPublic",
     "PermissionUpdate",
     "RolePermission",
+    "QuestionLocationItem",
+    "QuestionLocationsCreate",
+    "QuestionTagsCreate",
 ]
 
 # Rebuild models to resolve forward references after all imports are complete

--- a/backend/app/models/question.py
+++ b/backend/app/models/question.py
@@ -382,12 +382,15 @@ class QuestionRevisionCreate(QuestionBase):
     created_by_id: int = Field(description="ID of the user creating this revision")
 
 
-class QuestionLocationCreate(SQLModel):
-    """Data needed to add a location to a question"""
+class QuestionTagsCreate(SQLModel):
+    """Data needed to add one or more tags to a question."""
 
-    question_id: int = Field(
-        description="ID of the question to associate with this location"
-    )
+    tag_ids: list[int] = Field(description="IDs of tags to associate with the question")
+
+
+class QuestionLocationItem(SQLModel):
+    """Item for specifying a location to add to a question."""
+
     # Only one of these should be provided
     state_id: int | None = Field(
         default=None, description="ID of the state to associate"
@@ -400,10 +403,12 @@ class QuestionLocationCreate(SQLModel):
     )
 
 
-class QuestionTagCreate(SQLModel):
-    """Data needed to add a tag to a question"""
+class QuestionLocationsCreate(SQLModel):
+    """Data needed to add one or more locations to a question."""
 
-    tag_id: int = Field(description="ID of the tag to associate with the question")
+    locations: list[QuestionLocationItem] = Field(
+        description="List of locations to associate with the question"
+    )
 
 
 class QuestionLocationPublic(SQLModel):

--- a/backend/app/models/question.py
+++ b/backend/app/models/question.py
@@ -382,14 +382,16 @@ class QuestionRevisionCreate(QuestionBase):
     created_by_id: int = Field(description="ID of the user creating this revision")
 
 
-class QuestionTagsCreate(SQLModel):
-    """Data needed to add one or more tags to a question."""
+class QuestionTagsUpdate(SQLModel):
+    """Data to update all tags for a question."""
 
-    tag_ids: list[int] = Field(description="IDs of tags to associate with the question")
+    tag_ids: list[int] = Field(
+        description="The complete list of tag IDs to associate with the question"
+    )
 
 
-class QuestionLocationItem(SQLModel):
-    """Item for specifying a location to add to a question."""
+class QuestionLocationUpdateItem(SQLModel):
+    """Item for specifying a location to associate with a question."""
 
     # Only one of these should be provided
     state_id: int | None = Field(
@@ -403,11 +405,11 @@ class QuestionLocationItem(SQLModel):
     )
 
 
-class QuestionLocationsCreate(SQLModel):
-    """Data needed to add one or more locations to a question."""
+class QuestionLocationsUpdate(SQLModel):
+    """Data to update all locations for a question."""
 
-    locations: list[QuestionLocationItem] = Field(
-        description="List of locations to associate with the question"
+    locations: list[QuestionLocationUpdateItem] = Field(
+        description="The complete list of locations to associate with the question"
     )
 
 

--- a/backend/app/tests/api/routes/test_question.py
+++ b/backend/app/tests/api/routes/test_question.py
@@ -10,6 +10,7 @@ from app.models.location import Block, Country, District, State
 from app.models.organization import Organization
 from app.models.question import (
     Question,
+    QuestionLocation,
     QuestionRevision,
     QuestionTag,
     QuestionType,
@@ -682,39 +683,42 @@ def test_question_tag_operations(client: TestClient, db: SessionDep) -> None:
     assert len(data["tags"]) == 1
     assert data["tags"][0]["id"] == tag1.id
 
-    # Add another tag
-    response = client.post(
+    # Add another tag using PUT (sync approach)
+    response = client.put(
         f"{settings.API_V1_STR}/questions/{question_id}/tags",
         json={
-            "tag_ids": [tag2.id],
+            "tag_ids": [tag1.id, tag2.id],  # Keep tag1, add tag2
         },
     )
 
     assert response.status_code == 200
-    tag_data_list = response.json()
-    assert isinstance(tag_data_list, list)
-    assert len(tag_data_list) == 1
-    tag_data = tag_data_list[0]
-    assert tag_data["question_id"] == question_id
-    assert tag_data["tag_id"] == tag2.id
+    updated_tags = response.json()
+    assert len(updated_tags) == 2
+    tag_ids = {tag["id"] for tag in updated_tags}
+    assert tag_ids == {tag1.id, tag2.id}
 
-    # Get question tags
+    # Get question tags to verify
     response = client.get(f"{settings.API_V1_STR}/questions/{question_id}/tags")
     tags = response.json()
 
     assert response.status_code == 200
     assert len(tags) == 2
-    tag_ids = [tag["id"] for tag in tags]
+    tag_ids = {tag["id"] for tag in tags}
     assert tag1.id in tag_ids
     assert tag2.id in tag_ids
 
-    # Remove a tag
-    response = client.delete(
-        f"{settings.API_V1_STR}/questions/{question_id}/tags/{tag1.id}"
+    # Remove a tag using PUT (sync approach)
+    response = client.put(
+        f"{settings.API_V1_STR}/questions/{question_id}/tags",
+        json={
+            "tag_ids": [tag2.id],  # Keep only tag2, remove tag1
+        },
     )
 
     assert response.status_code == 200
-    assert "removed" in response.json()["message"]
+    updated_tags = response.json()
+    assert len(updated_tags) == 1
+    assert updated_tags[0]["id"] == tag2.id
 
     # Verify tag was removed
     response = client.get(f"{settings.API_V1_STR}/questions/{question_id}/tags")
@@ -744,6 +748,7 @@ def test_question_location_operations(client: TestClient, db: SessionDep) -> Non
     kerala = State(name="Kerala", country_id=india.id)
     db.add(kerala)
     db.commit()
+    db.refresh(kerala)
 
     # Create districts
     ernakulam = District(name="Ernakulam", state_id=kerala.id)
@@ -751,6 +756,8 @@ def test_question_location_operations(client: TestClient, db: SessionDep) -> Non
     db.add(ernakulam)
     db.add(thrissur)
     db.commit()
+    db.refresh(ernakulam)
+    db.refresh(thrissur)
 
     # Create blocks
     kovil = Block(name="Kovil", district_id=ernakulam.id)
@@ -758,11 +765,9 @@ def test_question_location_operations(client: TestClient, db: SessionDep) -> Non
     db.add(kovil)
     db.add(mayani)
     db.commit()
+    db.refresh(kovil)
 
     db.refresh(org)
-    db.refresh(kerala)
-    db.refresh(ernakulam)
-    db.refresh(kovil)
 
     question_data = {
         "organization_id": org.id,
@@ -792,81 +797,95 @@ def test_question_location_operations(client: TestClient, db: SessionDep) -> Non
     assert data["locations"][0]["district_id"] is None
     assert data["locations"][0]["block_id"] is None
 
-    # Test adding another location to the same question
-    location_data = {
-        "locations": [
-            {
-                "state_id": None,
-                "district_id": thrissur.id,
-                "block_id": None,
-            }
-        ]
-    }
-
-    response = client.post(
+    # Test adding another location using PUT (sync approach)
+    response = client.put(
         f"{settings.API_V1_STR}/questions/{data['id']}/locations",
-        json=location_data,
+        json={
+            "locations": [
+                {
+                    "state_id": kerala.id,
+                    "district_id": None,
+                    "block_id": None,
+                },  # Keep existing state
+                {
+                    "state_id": None,
+                    "district_id": thrissur.id,
+                    "block_id": None,
+                },  # Add district
+            ]
+        },
     )
 
     assert response.status_code == 200, response.text
     location_list = response.json()
     assert isinstance(location_list, list)
-    assert len(location_list) == 1
-    location = location_list[0]
-    assert location["state_id"] is None
-    assert location["district_id"] == thrissur.id
-    assert location["block_id"] is None
+    assert len(location_list) == 2
 
-    # check for block location as well
-    block_location_data = {
-        "locations": [
-            {
-                "state_id": None,
-                "district_id": None,
-                "block_id": kovil.id,
-            }
-        ]
-    }
+    # Verify we have both state and district locations
+    state_locations = [loc for loc in location_list if loc["state_id"] is not None]
+    district_locations = [
+        loc for loc in location_list if loc["district_id"] is not None
+    ]
+    assert len(state_locations) == 1
+    assert len(district_locations) == 1
+    assert state_locations[0]["state_id"] == kerala.id
+    assert district_locations[0]["district_id"] == thrissur.id
 
-    response = client.post(
+    # Add block location as well using PUT
+    response = client.put(
         f"{settings.API_V1_STR}/questions/{data['id']}/locations",
-        json=block_location_data,
+        json={
+            "locations": [
+                {
+                    "state_id": kerala.id,
+                    "district_id": None,
+                    "block_id": None,
+                },  # Keep state
+                {
+                    "state_id": None,
+                    "district_id": thrissur.id,
+                    "block_id": None,
+                },  # Keep district
+                {
+                    "state_id": None,
+                    "district_id": None,
+                    "block_id": kovil.id,
+                },  # Add block
+            ]
+        },
     )
 
     assert response.status_code == 200, response.text
     location_list = response.json()
     assert isinstance(location_list, list)
-    assert len(location_list) == 1
-    location = location_list[0]
-    assert location["state_id"] is None
-    assert location["district_id"] is None
-    assert location["block_id"] == kovil.id
+    assert len(location_list) == 3
 
-    # test location deletion endpoint
-    response = client.get(f"{settings.API_V1_STR}/questions/{data['id']}")
-    assert response.status_code == 200
-    question = response.json()
-    assert len(question["locations"]) == 3  # State, district, and block
+    # Find the block location
+    block_locations = [loc for loc in location_list if loc["block_id"] is not None]
+    assert len(block_locations) == 1
+    assert block_locations[0]["block_id"] == kovil.id
 
-    district_location_id = None
-    for loc in question["locations"]:
-        if loc["district_id"] == thrissur.id:
-            district_location_id = loc["id"]
-            break
-
-    assert district_location_id is not None
-
-    response = client.delete(
-        f"{settings.API_V1_STR}/questions/{data['id']}/locations/{district_location_id}"
+    # Test location removal using PUT (by excluding from the list)
+    response = client.put(
+        f"{settings.API_V1_STR}/questions/{data['id']}/locations",
+        json={
+            "locations": [
+                {
+                    "state_id": kerala.id,
+                    "district_id": None,
+                    "block_id": None,
+                },  # Keep state
+                {
+                    "state_id": None,
+                    "district_id": None,
+                    "block_id": kovil.id,
+                },  # Keep block, remove district
+            ]
+        },
     )
     assert response.status_code == 200
-    assert "removed" in response.json()["message"]
-
-    # Verify location was removed
-    response = client.get(f"{settings.API_V1_STR}/questions/{data['id']}")
-    assert response.status_code == 200
-    question = response.json()
-    assert len(question["locations"]) == 2  # Now only state and block
+    location_list = response.json()
+    assert len(location_list) == 2  # Now only state and block
 
     # Verify we can still filter by location
     response = client.get(f"{settings.API_V1_STR}/questions/?state_ids={kerala.id}")
@@ -1600,12 +1619,10 @@ def test_bulk_tag_operations(client: TestClient, db: SessionDep) -> None:
     assert response.status_code == 200
     question_id = response.json()["id"]
 
-    # Test bulk add tags
-    bulk_tag_data = {"tag_ids": [tags[0].id, tags[1].id, tags[2].id]}
-
-    response = client.post(
+    # Test bulk add tags using PUT
+    response = client.put(
         f"{settings.API_V1_STR}/questions/{question_id}/tags",
-        json=bulk_tag_data,
+        json={"tag_ids": [tags[0].id, tags[1].id, tags[2].id]},
     )
 
     assert response.status_code == 200
@@ -1614,56 +1631,49 @@ def test_bulk_tag_operations(client: TestClient, db: SessionDep) -> None:
     assert len(tag_results) == 3
 
     # Verify all tags were added
-    for _, tag_result in enumerate(tag_results):
-        assert tag_result["question_id"] == question_id
-        assert tag_result["tag_id"] in [tags[0].id, tags[1].id, tags[2].id]
+    tag_ids = {tag["id"] for tag in tag_results}
+    assert tag_ids == {tags[0].id, tags[1].id, tags[2].id}
 
     # Verify question has all the tags
     response = client.get(f"{settings.API_V1_STR}/questions/{question_id}/tags")
     current_tags = response.json()
     assert len(current_tags) == 3
 
-    # Test adding duplicate tags (should be skipped)
-    duplicate_tag_data = {
-        "tag_ids": [tags[0].id, tags[3].id]  # tags[0] already exists
-    }
-
-    response = client.post(
+    # Test adding more tags (should replace the existing set)
+    response = client.put(
         f"{settings.API_V1_STR}/questions/{question_id}/tags",
-        json=duplicate_tag_data,
+        json={
+            "tag_ids": [tags[0].id, tags[3].id]
+        },  # Keep tags[0], remove tags[1,2], add tags[3]
     )
 
     assert response.status_code == 200
     tag_results = response.json()
-    # Should return 2 results: existing one for tags[0] and new one for tags[3]
     assert len(tag_results) == 2
+    tag_ids = {tag["id"] for tag in tag_results}
+    assert tag_ids == {tags[0].id, tags[3].id}
 
-    # Verify we now have 4 tags total
-    response = client.get(f"{settings.API_V1_STR}/questions/{question_id}/tags")
-    current_tags = response.json()
-    assert len(current_tags) == 4
-
-    # Test bulk remove tags
-    tag_ids_to_remove = [tags[0].id, tags[1].id]
-    response = client.delete(
-        f"{settings.API_V1_STR}/questions/{question_id}/tags",
-        params={"tag_ids": tag_ids_to_remove},
-    )
-
-    assert response.status_code == 200
-    result = response.json()
-    assert "Removed 2 tag(s)" in result["message"]
-
-    # Verify tags were removed
+    # Verify we now have 2 tags total
     response = client.get(f"{settings.API_V1_STR}/questions/{question_id}/tags")
     current_tags = response.json()
     assert len(current_tags) == 2
 
-    remaining_tag_ids = [tag["id"] for tag in current_tags]
-    assert tags[0].id not in remaining_tag_ids
-    assert tags[1].id not in remaining_tag_ids
-    assert tags[2].id in remaining_tag_ids
-    assert tags[3].id in remaining_tag_ids
+    # Test bulk remove tags by setting to subset
+    response = client.put(
+        f"{settings.API_V1_STR}/questions/{question_id}/tags",
+        json={"tag_ids": [tags[3].id]},  # Keep only tags[3]
+    )
+
+    assert response.status_code == 200
+    tag_results = response.json()
+    assert len(tag_results) == 1
+    assert tag_results[0]["id"] == tags[3].id
+
+    # Verify tags were removed
+    response = client.get(f"{settings.API_V1_STR}/questions/{question_id}/tags")
+    current_tags = response.json()
+    assert len(current_tags) == 1
+    assert current_tags[0]["id"] == tags[3].id
 
 
 def test_bulk_location_operations(client: TestClient, db: SessionDep) -> None:
@@ -1737,35 +1747,33 @@ def test_bulk_location_operations(client: TestClient, db: SessionDep) -> None:
     assert response.status_code == 200
     question_id = response.json()["id"]
 
-    # Test bulk add locations
-    bulk_location_data = {
-        "locations": [
-            {
-                "state_id": states[0].id,
-                "district_id": None,
-                "block_id": None,
-            },
-            {
-                "state_id": states[1].id,
-                "district_id": None,
-                "block_id": None,
-            },
-            {
-                "state_id": None,
-                "district_id": districts[0].id,
-                "block_id": None,
-            },
-            {
-                "state_id": None,
-                "district_id": None,
-                "block_id": blocks[0].id,
-            },
-        ]
-    }
-
-    response = client.post(
+    # Test bulk add locations using PUT
+    response = client.put(
         f"{settings.API_V1_STR}/questions/{question_id}/locations",
-        json=bulk_location_data,
+        json={
+            "locations": [
+                {
+                    "state_id": states[0].id,
+                    "district_id": None,
+                    "block_id": None,
+                },
+                {
+                    "state_id": states[1].id,
+                    "district_id": None,
+                    "block_id": None,
+                },
+                {
+                    "state_id": None,
+                    "district_id": districts[0].id,
+                    "block_id": None,
+                },
+                {
+                    "state_id": None,
+                    "district_id": None,
+                    "block_id": blocks[0].id,
+                },
+            ]
+        },
     )
 
     assert response.status_code == 200
@@ -1791,61 +1799,54 @@ def test_bulk_location_operations(client: TestClient, db: SessionDep) -> None:
     question = response.json()
     assert len(question["locations"]) == 4
 
-    # Test adding duplicate locations (should be skipped)
-    duplicate_location_data = {
-        "locations": [
-            {
-                "state_id": states[0].id,  # Already exists
-                "district_id": None,
-                "block_id": None,
-            },
-            {
-                "state_id": states[2].id,  # New one
-                "district_id": None,
-                "block_id": None,
-            },
-        ]
-    }
-
-    response = client.post(
+    # Test modifying locations (add new, remove some existing)
+    response = client.put(
         f"{settings.API_V1_STR}/questions/{question_id}/locations",
-        json=duplicate_location_data,
+        json={
+            "locations": [
+                {
+                    "state_id": states[0].id,  # Keep this one
+                    "district_id": None,
+                    "block_id": None,
+                },
+                {
+                    "state_id": states[2].id,  # Add new state, remove states[1]
+                    "district_id": None,
+                    "block_id": None,
+                },
+                # Remove district and block entirely
+            ]
+        },
     )
 
     assert response.status_code == 200
     location_results = response.json()
-    # Should only return 1 result for the new state, duplicate should be skipped
-    assert len(location_results) == 1
-    assert location_results[0]["state_id"] == states[2].id
+    # Should only return 2 results for the new state
+    assert len(location_results) == 2
 
-    # Verify we now have 5 locations total
+    # Verify we now have only 2 locations total
     response = client.get(f"{settings.API_V1_STR}/questions/{question_id}")
     question = response.json()
-    assert len(question["locations"]) == 5
+    assert len(question["locations"]) == 2
 
-    # Test bulk remove locations
-    location_ids_to_remove = [
-        question["locations"][0]["id"],
-        question["locations"][1]["id"],
-    ]
-
-    response = client.delete(
+    # Test removing all locations
+    response = client.put(
         f"{settings.API_V1_STR}/questions/{question_id}/locations",
-        params={"location_ids": location_ids_to_remove},
+        json={"locations": []},
     )
 
     assert response.status_code == 200
-    result = response.json()
-    assert "Removed 2 location(s)" in result["message"]
+    location_results = response.json()
+    assert len(location_results) == 0
 
-    # Verify locations were removed
+    # Verify all locations were removed
     response = client.get(f"{settings.API_V1_STR}/questions/{question_id}")
     question = response.json()
-    assert len(question["locations"]) == 3
+    assert len(question["locations"]) == 0
 
 
 def test_mixed_single_and_bulk_operations(client: TestClient, db: SessionDep) -> None:
-    """Test that single and bulk operations work together seamlessly."""
+    """Test that the PUT update operations work seamlessly."""
     # Create organization
     org = Organization(name=random_lower_string())
     db.add(org)
@@ -1902,20 +1903,18 @@ def test_mixed_single_and_bulk_operations(client: TestClient, db: SessionDep) ->
     assert response.status_code == 200
     question_id = response.json()["id"]
 
-    # Add a single tag
-    single_tag_data = {"tag_ids": [tags[0].id]}
-    response = client.post(
+    # Add a single tag using PUT
+    response = client.put(
         f"{settings.API_V1_STR}/questions/{question_id}/tags",
-        json=single_tag_data,
+        json={"tag_ids": [tags[0].id]},
     )
     assert response.status_code == 200
     assert len(response.json()) == 1
 
-    # Add multiple tags
-    bulk_tag_data = {"tag_ids": [tags[1].id, tags[2].id]}
-    response = client.post(
+    # Add multiple tags using PUT (replace previous)
+    response = client.put(
         f"{settings.API_V1_STR}/questions/{question_id}/tags",
-        json=bulk_tag_data,
+        json={"tag_ids": [tags[1].id, tags[2].id]},
     )
     assert response.status_code == 200
     assert len(response.json()) == 2
@@ -1923,18 +1922,21 @@ def test_mixed_single_and_bulk_operations(client: TestClient, db: SessionDep) ->
     # Verify all tags are present
     response = client.get(f"{settings.API_V1_STR}/questions/{question_id}/tags")
     current_tags = response.json()
-    assert len(current_tags) == 3
+    assert len(current_tags) == 2
+    tag_ids = {tag["id"] for tag in current_tags}
+    assert tag_ids == {tags[1].id, tags[2].id}
 
-    # Remove single tag
-    response = client.delete(
-        f"{settings.API_V1_STR}/questions/{question_id}/tags/{tags[0].id}"
+    # Update to have all three tags using PUT
+    response = client.put(
+        f"{settings.API_V1_STR}/questions/{question_id}/tags",
+        json={"tag_ids": [tags[0].id, tags[1].id, tags[2].id]},
     )
     assert response.status_code == 200
 
-    # Remove multiple tags
-    response = client.delete(
+    # Remove all tags using PUT
+    response = client.put(
         f"{settings.API_V1_STR}/questions/{question_id}/tags",
-        params={"tag_ids": [tags[1].id, tags[2].id]},
+        json={"tag_ids": []},
     )
     assert response.status_code == 200
 
@@ -1942,3 +1944,167 @@ def test_mixed_single_and_bulk_operations(client: TestClient, db: SessionDep) ->
     response = client.get(f"{settings.API_V1_STR}/questions/{question_id}/tags")
     current_tags = response.json()
     assert len(current_tags) == 0
+
+
+def test_update_question_tags(client: TestClient, db: SessionDep) -> None:
+    """Test updating all tags for a question using PUT."""
+    # Create organization, user, and initial tags
+    org = Organization(name=random_lower_string())
+    db.add(org)
+    user = create_random_user(db)
+    tag_type = TagType(
+        name="Update Test Category",
+        created_by_id=user.id,
+        organization_id=org.id,
+    )
+    db.add(tag_type)
+    db.flush()
+
+    tags = []
+    for i in range(5):
+        tag = Tag(
+            name=f"UpdateTag{i}",
+            tag_type_id=tag_type.id,
+            created_by_id=user.id,
+            organization_id=org.id,
+        )
+        db.add(tag)
+        tags.append(tag)
+
+    db.commit()
+    for tag in tags:
+        db.refresh(tag)
+
+    # Create a question with initial tags (tag0, tag1)
+    question = Question(organization_id=org.id)
+    db.add(question)
+    db.flush()
+    question.revisions.append(
+        QuestionRevision(
+            question_id=question.id,
+            question_text="test",
+            created_by_id=user.id,
+            question_type=QuestionType.single_choice,
+        )
+    )
+    db.add(QuestionTag(question_id=question.id, tag_id=tags[0].id))
+    db.add(QuestionTag(question_id=question.id, tag_id=tags[1].id))
+    db.commit()
+    db.refresh(question)
+
+    # 1. Test Sync: remove tag1, keep tag0, add tag2, tag3
+    update_payload = {"tag_ids": [tags[0].id, tags[2].id, tags[3].id]}
+    response = client.put(
+        f"{settings.API_V1_STR}/questions/{question.id}/tags",
+        json=update_payload,
+    )
+
+    assert response.status_code == 200
+    updated_tags = response.json()
+    assert len(updated_tags) == 3
+    updated_tag_ids = {t["id"] for t in updated_tags}
+    assert updated_tag_ids == {tags[0].id, tags[2].id, tags[3].id}
+
+    # 2. Test Add: send all existing plus a new one
+    update_payload = {"tag_ids": [tags[0].id, tags[2].id, tags[3].id, tags[4].id]}
+    response = client.put(
+        f"{settings.API_V1_STR}/questions/{question.id}/tags",
+        json=update_payload,
+    )
+    assert response.status_code == 200
+    assert len(response.json()) == 4
+
+    # 3. Test Remove: send a subset of existing
+    update_payload = {"tag_ids": [tags[2].id]}
+    response = client.put(
+        f"{settings.API_V1_STR}/questions/{question.id}/tags",
+        json=update_payload,
+    )
+    assert response.status_code == 200
+    assert len(response.json()) == 1
+    assert response.json()[0]["id"] == tags[2].id
+
+    # 4. Test Clear All: send an empty list
+    update_payload = {"tag_ids": []}
+    response = client.put(
+        f"{settings.API_V1_STR}/questions/{question.id}/tags",
+        json=update_payload,
+    )
+    assert response.status_code == 200
+    assert len(response.json()) == 0
+
+
+def test_update_question_locations(client: TestClient, db: SessionDep) -> None:
+    # Create organization and user
+    org = Organization(name=random_lower_string())
+    db.add(org)
+    user = create_random_user(db)
+
+    # Create locations
+    country = Country(name="Country")
+    db.add(country)
+    db.commit()
+    db.refresh(country)
+
+    state1 = State(name="State1", country_id=country.id)
+    state2 = State(name="State2", country_id=country.id)
+    db.add_all([state1, state2])
+    db.commit()
+    db.refresh(state1)
+    db.refresh(state2)
+
+    district1 = District(name="District1", state_id=state1.id)
+    db.add(district1)
+    db.commit()
+    db.refresh(district1)
+
+    block1 = Block(name="Block1", district_id=district1.id)
+    db.add(block1)
+    db.commit()
+    db.refresh(block1)
+
+    # Create question with initial location (state1)
+    question = Question(organization_id=org.id)
+    db.add(question)
+    db.flush()
+    question.revisions.append(
+        QuestionRevision(
+            question_id=question.id,
+            question_text="test",
+            created_by_id=user.id,
+            question_type=QuestionType.single_choice,
+        )
+    )
+    db.add(QuestionLocation(question_id=question.id, state_id=state1.id))
+    db.commit()
+
+    # Test sync: keep state1, add district1 and block1
+    update_payload = {
+        "locations": [
+            {"state_id": state1.id, "district_id": None, "block_id": None},
+            {"state_id": None, "district_id": district1.id, "block_id": None},
+            {"state_id": None, "district_id": None, "block_id": block1.id},
+        ]
+    }
+    response = client.put(
+        f"{settings.API_V1_STR}/questions/{question.id}/locations",
+        json=update_payload,
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 3
+    state_ids = {loc["state_id"] for loc in data if loc["state_id"]}
+    district_ids = {loc["district_id"] for loc in data if loc["district_id"]}
+    block_ids = {loc["block_id"] for loc in data if loc["block_id"]}
+    assert state_ids == {state1.id}
+    assert district_ids == {district1.id}
+    assert block_ids == {block1.id}
+
+    # Test clear: send empty list
+    response = client.put(
+        f"{settings.API_V1_STR}/questions/{question.id}/locations",
+        json={"locations": []},
+    )
+    assert response.status_code == 200
+    assert len(response.json()) == 0


### PR DESCRIPTION
Fixes issue: #104 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for synchronizing all locations or tags of a question in a single update request.
- **Bug Fixes**
  - Improved handling to silently skip duplicates or missing locations/tags during batch operations.
- **Tests**
  - Enhanced test coverage for bulk and mixed operations on question tags and locations, ensuring correct behavior for batch actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->