### PR TITLE
Add Timer APIs for Test Start and Time Left

### DIFF
--- a/backend/app/api/routes/candidate.py
+++ b/backend/app/api/routes/candidate.py
@@ -663,11 +663,11 @@ def get_time_left(
         remaining_by_endtime = test.end_time - current_time
         remaining_times.append(remaining_by_endtime)
     if not remaining_times:
-        return {"time_left_seconds": None}
+        return {"time_left": None}
     final_time_left = min(remaining_times)
     if final_time_left.total_seconds() <= 0:
-        return {"time_left_seconds": 0}
+        return {"time_left": 0}
 
-    time_left_seconds = int(final_time_left.total_seconds())
+    time_left = int(final_time_left.total_seconds())
 
-    return {"time_left_seconds": int(time_left_seconds)}
+    return {"time_left": int(time_left)}

--- a/backend/app/api/routes/candidate.py
+++ b/backend/app/api/routes/candidate.py
@@ -592,8 +592,7 @@ def get_time_left(
     if not test:
         raise HTTPException(status_code=404, detail="Associated test not found")
     current_time = datetime.now()
-    if not candidate_test.start_time:
-        return {"time_left": "0"}
+
     start_time = candidate_test.start_time
     if start_time.tzinfo is None:
         start_time = start_time.replace(tzinfo=timezone.utc)
@@ -608,12 +607,12 @@ def get_time_left(
         remaining_times.append(remaining_by_endtime)
     if not remaining_times:
         return {
-            "time_left": "0",
+            "time_left_seconds": "0",
             "message": "No time limit or end time is set for this test.",
         }
     final_time_left = min(remaining_times)
     if final_time_left.total_seconds() <= 0:
-        return {"time_left": "0"}
+        return {"time_left_seconds": "0"}
 
     time_left_seconds = int(final_time_left.total_seconds())
     time_left_str = str(time_left_seconds)

--- a/backend/app/api/routes/candidate.py
+++ b/backend/app/api/routes/candidate.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Body, Depends, HTTPException, Query
 from sqlmodel import SQLModel, not_, select
 
 from app.api.deps import SessionDep, permission_dependency
+from app.api.routes.utils import get_current_time
 from app.models import (
     BatchAnswerSubmitRequest,
     Candidate,
@@ -29,7 +30,7 @@ from app.models import (
     TestQuestion,
 )
 from app.models.candidate import Result
-from app.models.utils import TimeLeft, get_current_time
+from app.models.utils import TimeLeft
 
 router = APIRouter(prefix="/candidate", tags=["Candidate"])
 router_candidate_test = APIRouter(prefix="/candidate_test", tags=["Candidate Test"])
@@ -663,11 +664,10 @@ def get_time_left(
         remaining_by_endtime = test.end_time - current_time
         remaining_times.append(remaining_by_endtime)
     if not remaining_times:
-        return {"time_left": None}
+        return TimeLeft(time_left=None)
     final_time_left = min(remaining_times)
     if final_time_left.total_seconds() <= 0:
-        return {"time_left": 0}
+        return TimeLeft(time_left=0)
 
     time_left = int(final_time_left.total_seconds())
-
-    return {"time_left": int(time_left)}
+    return TimeLeft(time_left=time_left)

--- a/backend/app/api/routes/test.py
+++ b/backend/app/api/routes/test.py
@@ -522,11 +522,10 @@ def get_time_before_test_start_public(test_uuid: str, session: SessionDep) -> Ti
     if not test or test.is_deleted or test.is_active is False:
         raise HTTPException(status_code=404, detail="Test not found or not active")
     if test.start_time is None:
-        return TimeLeft(time_left=None)
+        return TimeLeft(time_left=0)
     current_time = get_current_time()
     start_time = test.start_time
     if current_time >= start_time:
-        print("Test has already started or is in progress")
         return TimeLeft(time_left=0)
     seconds_left = (start_time - current_time).total_seconds()
     return TimeLeft(time_left=int(seconds_left))

--- a/backend/app/api/routes/test.py
+++ b/backend/app/api/routes/test.py
@@ -521,10 +521,11 @@ def get_time_before_test_start_public(test_uuid: str, session: SessionDep) -> Ti
     if not test or test.is_deleted or test.is_active is False:
         raise HTTPException(status_code=404, detail="Test not found or not active")
     if test.start_time is None:
-        return {"time_left_seconds": None}
+        return {"time_left": None}
     current_time = get_current_time()
     start_time = test.start_time
     if current_time >= start_time:
-        return {"time_left_seconds": 0}
+        print("Test has already started or is in progress")
+        return {"time_left": 0}
     seconds_left = (start_time - current_time).total_seconds()
-    return {"time_left_seconds": int(seconds_left)}
+    return {"time_left": int(seconds_left)}

--- a/backend/app/api/routes/test.py
+++ b/backend/app/api/routes/test.py
@@ -20,6 +20,7 @@ from app.models import (
 )
 from app.models.tag import Tag
 from app.models.test import MarksLevelEnum
+from app.models.utils import TimeLeft, get_current_time
 
 router = APIRouter(prefix="/test", tags=["Test"])
 
@@ -514,18 +515,16 @@ def delete_test(test_id: int, session: SessionDep) -> Message:
     return Message(message="Test deleted successfully")
 
 
-@router.get("/public/time_left/{test_uuid}")
-def get_time_before_test_start_public(
-    test_uuid: str, session: SessionDep
-) -> dict[str, str]:
+@router.get("/public/time_left/{test_uuid}", response_model=TimeLeft)
+def get_time_before_test_start_public(test_uuid: str, session: SessionDep) -> TimeLeft:
     test = session.exec(select(Test).where(Test.link == test_uuid)).first()
     if not test or test.is_deleted or test.is_active is False:
         raise HTTPException(status_code=404, detail="Test not found or not active")
     if test.start_time is None:
-        return {"time_left_seconds": "0"}
-    current_time = datetime.now()
+        return {"time_left_seconds": None}
+    current_time = get_current_time()
     start_time = test.start_time
     if current_time >= start_time:
-        return {"time_left_seconds": "0"}
+        return {"time_left_seconds": 0}
     seconds_left = (start_time - current_time).total_seconds()
-    return {"time_left_seconds": str(int(seconds_left))}
+    return {"time_left_seconds": int(seconds_left)}

--- a/backend/app/api/routes/test.py
+++ b/backend/app/api/routes/test.py
@@ -522,10 +522,10 @@ def get_time_before_test_start_public(
     if not test or test.is_deleted or test.is_active is False:
         raise HTTPException(status_code=404, detail="Test not found or not active")
     if test.start_time is None:
-        return {"time_left": "0"}
+        return {"time_left_seconds": "0"}
     current_time = datetime.now()
     start_time = test.start_time
     if current_time >= start_time:
-        return {"time_left": "0"}
+        return {"time_left_seconds": "0"}
     seconds_left = (start_time - current_time).total_seconds()
     return {"time_left_seconds": str(int(seconds_left))}

--- a/backend/app/api/routes/test.py
+++ b/backend/app/api/routes/test.py
@@ -5,6 +5,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlmodel import col, select
 
 from app.api.deps import SessionDep, permission_dependency
+from app.api.routes.utils import get_current_time
 from app.models import (
     Message,
     QuestionRevision,
@@ -20,7 +21,7 @@ from app.models import (
 )
 from app.models.tag import Tag
 from app.models.test import MarksLevelEnum
-from app.models.utils import TimeLeft, get_current_time
+from app.models.utils import TimeLeft
 
 router = APIRouter(prefix="/test", tags=["Test"])
 
@@ -521,11 +522,11 @@ def get_time_before_test_start_public(test_uuid: str, session: SessionDep) -> Ti
     if not test or test.is_deleted or test.is_active is False:
         raise HTTPException(status_code=404, detail="Test not found or not active")
     if test.start_time is None:
-        return {"time_left": None}
+        return TimeLeft(time_left=None)
     current_time = get_current_time()
     start_time = test.start_time
     if current_time >= start_time:
         print("Test has already started or is in progress")
-        return {"time_left": 0}
+        return TimeLeft(time_left=0)
     seconds_left = (start_time - current_time).total_seconds()
-    return {"time_left": int(seconds_left)}
+    return TimeLeft(time_left=int(seconds_left))

--- a/backend/app/api/routes/test.py
+++ b/backend/app/api/routes/test.py
@@ -512,3 +512,20 @@ def delete_test(test_id: int, session: SessionDep) -> Message:
     session.refresh(test)
 
     return Message(message="Test deleted successfully")
+
+
+@router.get("/public/time_left/{test_uuid}")
+def get_time_before_test_start_public(
+    test_uuid: str, session: SessionDep
+) -> dict[str, str]:
+    test = session.exec(select(Test).where(Test.link == test_uuid)).first()
+    if not test or test.is_deleted or test.is_active is False:
+        raise HTTPException(status_code=404, detail="Test not found or not active")
+    if test.start_time is None:
+        return {"time_left": "0"}
+    current_time = datetime.now()
+    start_time = test.start_time
+    if current_time >= start_time:
+        return {"time_left": "0"}
+    seconds_left = (start_time - current_time).total_seconds()
+    return {"time_left_seconds": str(int(seconds_left))}

--- a/backend/app/api/routes/utils.py
+++ b/backend/app/api/routes/utils.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from fastapi import APIRouter, Depends
 from pydantic.networks import EmailStr
 
@@ -29,3 +31,8 @@ def test_email(email_to: EmailStr) -> Message:
 @router.get("/health-check/")
 async def health_check() -> bool:
     return True
+
+
+def get_current_time() -> datetime:
+    """Returns the current datetime."""
+    return datetime.now()

--- a/backend/app/models/utils.py
+++ b/backend/app/models/utils.py
@@ -1,6 +1,18 @@
+from datetime import datetime
+
 from sqlmodel import SQLModel
+from typing_extensions import TypedDict
 
 
 # Generic message
 class Message(SQLModel):
     message: str
+
+
+class TimeLeft(TypedDict):
+    time_left_seconds: int | None
+
+
+def get_current_time() -> datetime:
+    """Returns the current datetime."""
+    return datetime.now()

--- a/backend/app/models/utils.py
+++ b/backend/app/models/utils.py
@@ -10,7 +10,7 @@ class Message(SQLModel):
 
 
 class TimeLeft(TypedDict):
-    time_left_seconds: int | None
+    time_left: int | None
 
 
 def get_current_time() -> datetime:

--- a/backend/app/models/utils.py
+++ b/backend/app/models/utils.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-
 from sqlmodel import SQLModel
 from typing_extensions import TypedDict
 
@@ -11,8 +9,3 @@ class Message(SQLModel):
 
 class TimeLeft(TypedDict):
     time_left: int | None
-
-
-def get_current_time() -> datetime:
-    """Returns the current datetime."""
-    return datetime.now()

--- a/backend/app/tests/api/routes/test_candidate.py
+++ b/backend/app/tests/api/routes/test_candidate.py
@@ -2477,7 +2477,6 @@ def test_candidate_timer_with_specific_dates(
 
         candidate_test = CandidateTest(
             test_id=test.id,
-            created_by_id=user.id,
             candidate_id=candidate.id,
             device="Laptop",
             consent=True,

--- a/backend/app/tests/api/routes/test_candidate.py
+++ b/backend/app/tests/api/routes/test_candidate.py
@@ -6,6 +6,7 @@ from fastapi.testclient import TestClient
 from sqlmodel import select
 
 from app.api.deps import SessionDep
+from app.api.routes.utils import get_current_time
 from app.core.config import settings
 from app.models import (
     Candidate,
@@ -19,7 +20,6 @@ from app.models import (
 )
 from app.models.question import QuestionType
 from app.models.test import TestQuestion
-from app.models.utils import get_current_time
 from app.tests.utils.question_revisions import create_random_question_revision
 from app.tests.utils.user import create_random_user
 

--- a/backend/app/tests/api/routes/test_candidate.py
+++ b/backend/app/tests/api/routes/test_candidate.py
@@ -2324,8 +2324,8 @@ def test_candidate_timer_raises_if_timelimit_and_end_time_not_set(
 
     assert response.status_code == 200
     data = response.json()
-    assert "time_left" in data
-    assert data["time_left"] == "0"
+    assert "time_left_seconds" in data
+    assert data["time_left_seconds"] == "0"
     assert data.get("message") == "No time limit or end time is set for this test."
 
 

--- a/backend/app/tests/api/routes/test_candidate.py
+++ b/backend/app/tests/api/routes/test_candidate.py
@@ -2203,7 +2203,6 @@ def test_candidate_timer_with_specific_dates(
     db.refresh(candidate_test)
 
     response = client.get(f"{settings.API_V1_STR}/candidate/timer/{candidate_test.id}")
-    print("datetime4", response.json())
 
     assert response.status_code == 200
     data = response.json()
@@ -2332,7 +2331,7 @@ def test_pretest_timer_returns_time_left(client: TestClient, db: SessionDep) -> 
         f"{settings.API_V1_STR}/candidate/pretest_timer/{candidate_test.id}"
     )
     minutes_left = response.json()
-    print("minutes_left", minutes_left)
+
     assert response.status_code == 200
 
     assert isinstance(minutes_left, float)

--- a/backend/app/tests/api/routes/test_candidate.py
+++ b/backend/app/tests/api/routes/test_candidate.py
@@ -2163,6 +2163,10 @@ def test_convert_to_list_with_int_reponse(
 def test_candidate_timer_with_specific_dates(
     client: TestClient, db: SessionDep
 ) -> None:
+    candidate = Candidate(identity=uuid.uuid4())
+    db.add(candidate)
+    db.commit()
+    db.refresh(candidate)
     user = create_random_user(db)
     org = Organization(name=random_lower_string())
 
@@ -2172,14 +2176,11 @@ def test_candidate_timer_with_specific_dates(
     db.add(org)
     db.commit()
     db.refresh(org)
-    candidate = Candidate(identity=uuid.uuid4())
-    db.add(candidate)
-    db.commit()
-    db.refresh(candidate)
+
     test = Test(
         name="Date Based Test",
-        start_time=datetime(2025, 6, 23, 12, 0, 0),  # June 2, 12:00 PM
-        end_time=datetime(2025, 6, 25, 12, 0, 0),  # June 5, 12:00 PM
+        start_time=datetime.now() - timedelta(minutes=30),
+        end_time=datetime.now() + timedelta(minutes=40),
         time_limit=60,  # 60 minutes time limit
         is_active=True,
         created_by_id=user.id,
@@ -2188,78 +2189,50 @@ def test_candidate_timer_with_specific_dates(
     db.commit()
     db.refresh(test)
 
-    simulated_start_time = datetime.now() - timedelta(minutes=20)
     candidate_test = CandidateTest(
         test_id=test.id,
         created_by_id=user.id,
         candidate_id=candidate.id,
         device="Laptop",
         consent=True,
-        start_time=simulated_start_time,
+        start_time=datetime.now() - timedelta(minutes=30),
         is_submitted=False,
     )
     db.add(candidate_test)
     db.commit()
     db.refresh(candidate_test)
 
-    response = client.get(f"{settings.API_V1_STR}/candidate/timer/{candidate_test.id}")
+    response = client.get(
+        f"{settings.API_V1_STR}/candidate/time_left/{candidate_test.id}",
+        params={"candidate_uuid": str(candidate.identity)},
+    )
 
     assert response.status_code == 200
     data = response.json()
-    assert "time_left" in data
-    time_left = data["time_left"]
-    parts = time_left.split(":")
-    assert len(parts) == 3
-    assert all(part.isdigit() for part in parts)
-    hours, minutes, seconds = map(int, parts)
-    assert 0 <= hours <= 1
-    assert 0 <= minutes < 60
-    assert 0 <= seconds < 60
+    print("data090", data)
+    assert "time_left_seconds" in data
+    time_left = data["time_left_seconds"]
+    assert time_left.isdigit()
+    time_left = int(time_left)
+    assert 1795 <= time_left <= 1800
 
 
-def test_candidate_timer_candidate_test_not_found(client: TestClient) -> None:
-    # Try accessing a non-existing candidate test ID (e.g., 99999)
-    response = client.get(f"{settings.API_V1_STR}/candidate/timer/99999")
-
-    # Assert 404 response
-    assert response.status_code == 404
-    assert response.json()["detail"] == "Candidate test not found"
-
-
-def test_candidate_timer_time_is_over(client: TestClient, db: SessionDep) -> None:
-    user = create_random_user(db)
+def test_candidate_timer_candidate_test_not_found(
+    client: TestClient, db: SessionDep
+) -> None:
     candidate = Candidate(identity=uuid.uuid4())
     db.add(candidate)
     db.commit()
     db.refresh(candidate)
-    now = datetime.now()
-    test = Test(
-        name="Expired Test",
-        start_time=now - timedelta(days=1),
-        end_time=now + timedelta(days=1),  # still ongoing
-        time_limit=5,  # 5 minutes time limit
-        is_active=True,
-        created_by_id=user.id,
+    # Try accessing a non-existing candidate test ID (e.g., 99999)
+    response = client.get(
+        f"{settings.API_V1_STR}/candidate/time_left/99999",
+        params={"candidate_uuid": str(candidate.identity)},
     )
-    db.add(test)
-    db.commit()
-    db.refresh(test)
-    started_at = now - timedelta(minutes=6)
-    candidate_test = CandidateTest(
-        test_id=test.id,
-        candidate_id=candidate.id,
-        created_by_id=user.id,
-        start_time=started_at,
-        is_submitted=False,
-        device="Laptop",
-        consent=True,
-    )
-    db.add(candidate_test)
-    db.commit()
-    db.refresh(candidate_test)
-    response = client.get(f"{settings.API_V1_STR}/candidate/timer/{candidate_test.id}")
-    assert response.status_code == 400
-    assert response.json()["detail"] == "Time is over"
+
+    # Assert 404 response
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Candidate test not found or invalid UUID"
 
 
 def test_candidate_timer_end_time_takes_priority(
@@ -2294,91 +2267,19 @@ def test_candidate_timer_end_time_takes_priority(
     db.add(candidate_test)
     db.commit()
     db.refresh(candidate_test)
-    response = client.get(f"{settings.API_V1_STR}/candidate/timer/{candidate_test.id}")
-    assert response.status_code == 200
-
-
-def test_pretest_timer_returns_time_left(client: TestClient, db: SessionDep) -> None:
-    user = create_random_user(db)
-    candidate = Candidate(identity=uuid.uuid4())
-    db.add(candidate)
-    db.commit()
-    db.refresh(candidate)
-    test_start_time = datetime.now() + timedelta(hours=1)
-    test = Test(
-        name="Upcoming Test",
-        start_time=test_start_time,
-        end_time=test_start_time + timedelta(hours=2),
-        time_limit=60,
-        is_active=True,
-        created_by_id=user.id,
-    )
-    db.add(test)
-    db.commit()
-    db.refresh(test)
-    candidate_test = CandidateTest(
-        test_id=test.id,
-        candidate_id=candidate.id,
-        device="Laptop",
-        consent=True,
-        is_submitted=False,
-        start_time=datetime.now(),
-    )
-    db.add(candidate_test)
-    db.commit()
-    db.refresh(candidate_test)
     response = client.get(
-        f"{settings.API_V1_STR}/candidate/pretest_timer/{candidate_test.id}"
+        f"{settings.API_V1_STR}/candidate/time_left/{candidate_test.id}",
+        params={"candidate_uuid": str(candidate.identity)},
     )
-    minutes_left = response.json()
-
     assert response.status_code == 200
+    data = response.json()
+    assert "time_left_seconds" in data
 
-    assert isinstance(minutes_left, float)
-    assert 59.0 < minutes_left <= 60.0  # Should be just under 60 minutes
-
-
-def test_pretest_timer_test_already_started(client: TestClient, db: SessionDep) -> None:
-    user = create_random_user(db)
-    candidate = Candidate(identity=uuid.uuid4())
-    db.add_all([user, candidate])
-    db.commit()
-    db.refresh(user)
-    db.refresh(candidate)
-    test_start_time = datetime(2024, 6, 20, 10, 0, 0)
-    test_end_time = datetime(2024, 6, 20, 11, 0, 0)
-    test = Test(
-        name="Test Already Started",
-        start_time=test_start_time,
-        end_time=test_end_time,
-        time_limit=60,
-        is_active=True,
-        created_by_id=user.id,
-    )
-    db.add(test)
-    db.commit()
-    db.refresh(test)
-    candidate_test = CandidateTest(
-        test_id=test.id,
-        candidate_id=candidate.id,
-        device="Laptop",
-        consent=True,
-        is_submitted=False,
-        start_time=datetime(2025, 6, 20, 10, 0, 0),
-    )
-    db.add(candidate_test)
-    db.commit()
-    db.refresh(candidate_test)
-    response = client.get(
-        f"{settings.API_V1_STR}/candidate/pretest_timer/{candidate_test.id}"
-    )
-
-    # Step 5: Assert the result
-    assert response.status_code == 400
-    assert response.json()["detail"] == "Test has already started"
+    time_left_seconds = int(data["time_left_seconds"])
+    assert 295 <= time_left_seconds <= 300
 
 
-def test_candidate_timer_raises_if_time_limit_not_set(
+def test_candidate_timer_raises_if_timelimit_and_end_time_not_set(
     client: TestClient, db: SessionDep, get_user_superadmin_token: dict[str, str]
 ) -> None:
     user = create_random_user(db)
@@ -2416,32 +2317,58 @@ def test_candidate_timer_raises_if_time_limit_not_set(
     db.refresh(candidate_test)
 
     response = client.get(
-        f"{settings.API_V1_STR}/candidate/timer/{candidate_test.id}",
+        f"{settings.API_V1_STR}/candidate/time_left/{candidate_test.id}",
         params={"candidate_uuid": str(candidate.identity)},
         headers=get_user_superadmin_token,
     )
 
-    # Assert the API returns 400 with correct message
-    assert response.status_code == 400
-    assert response.json()["detail"] == "Test time limit is not set"
-    test.time_limit = 60
+    assert response.status_code == 200
+    data = response.json()
+    assert "time_left" in data
+    assert data["time_left"] == "0"
+    assert data.get("message") == "No time limit or end time is set for this test."
 
-    candidate_test.end_time = None
+
+def test_candidate_timer_with_only_time_limit(
+    client: TestClient, db: SessionDep
+) -> None:
+    # Create a candidate with random UUID
+    candidate = Candidate(identity=uuid.uuid4())
+    db.add(candidate)
+    db.commit()
+    db.refresh(candidate)
+
+    # Create a user
+    user = create_random_user(db)
+    test = Test(
+        name="Only Time Limit Test",
+        time_limit=30,  # 30 minutes
+        end_time=None,
+        start_time=datetime.now() - timedelta(minutes=5),  # test started 5 minutes ago
+        is_active=True,
+        created_by_id=user.id,
+    )
+    db.add(test)
+    db.commit()
+    db.refresh(test)
+    candidate_test = CandidateTest(
+        test_id=test.id,
+        created_by_id=user.id,
+        candidate_id=candidate.id,
+        device="Laptop",
+        consent=True,
+        start_time=datetime.now() - timedelta(minutes=5),
+        is_submitted=False,
+    )
     db.add(candidate_test)
     db.commit()
+    db.refresh(candidate_test)
     response = client.get(
-        f"{settings.API_V1_STR}/candidate/timer/{candidate_test.id}",
+        f"{settings.API_V1_STR}/candidate/time_left/{candidate_test.id}",
         params={"candidate_uuid": str(candidate.identity)},
-        headers=get_user_superadmin_token,
     )
-    assert response.status_code == 400
-    assert response.json()["detail"] == "Test end time is not set"
-
-
-def test_candidate_prestart_timer_candidate_test_not_found(client: TestClient) -> None:
-    # Try accessing a non-existing candidate test ID (e.g., 99999)
-    response = client.get(f"{settings.API_V1_STR}/candidate/pretest_timer/99999")
-
-    # Assert 404 response
-    assert response.status_code == 404
-    assert response.json()["detail"] == "Candidate test not found"
+    assert response.status_code == 200
+    data = response.json()
+    assert "time_left_seconds" in data
+    assert data["time_left_seconds"].isdigit()
+    assert 1495 <= int(data["time_left_seconds"]) <= 1500  # 30 minutes in seconds

--- a/backend/app/tests/api/routes/test_candidate.py
+++ b/backend/app/tests/api/routes/test_candidate.py
@@ -2492,8 +2492,8 @@ def test_candidate_timer_with_specific_dates(
     assert response.status_code == 200
     data = response.json()
     print("data090", data)
-    assert "time_left_seconds" in data
-    time_left = data["time_left_seconds"]
+    assert "time_left" in data
+    time_left = data["time_left"]
     assert isinstance(time_left, int)
 
     assert 1795 <= time_left <= 1800
@@ -2555,10 +2555,10 @@ def test_candidate_timer_end_time_takes_priority(
     )
     assert response.status_code == 200
     data = response.json()
-    assert "time_left_seconds" in data
+    assert "time_left" in data
 
-    time_left_seconds = int(data["time_left_seconds"])
-    assert 295 <= time_left_seconds <= 300
+    time_left = int(data["time_left"])
+    assert 295 <= time_left <= 300
 
 
 def test_candidate_timer_raises_if_timelimit_and_end_time_not_set(
@@ -2606,9 +2606,9 @@ def test_candidate_timer_raises_if_timelimit_and_end_time_not_set(
 
     assert response.status_code == 200
     data = response.json()
-    assert "time_left_seconds" in data
+    assert "time_left" in data
 
-    assert data["time_left_seconds"] is None
+    assert data["time_left"] is None
 
 
 def test_candidate_timer_with_only_time_limit(
@@ -2652,6 +2652,6 @@ def test_candidate_timer_with_only_time_limit(
     )
     assert response.status_code == 200
     data = response.json()
-    assert "time_left_seconds" in data
-    assert isinstance(data["time_left_seconds"], int)
-    assert 1495 <= int(data["time_left_seconds"]) <= 1500  # 30 minutes in seconds
+    assert "time_left" in data
+    assert isinstance(data["time_left"], int)
+    assert 1495 <= int(data["time_left"]) <= 1500  # 30 minutes in seconds

--- a/backend/app/tests/api/routes/test_test.py
+++ b/backend/app/tests/api/routes/test_test.py
@@ -1,9 +1,9 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any
 
 from fastapi import status
 from fastapi.testclient import TestClient
-from sqlmodel import delete, select
+from sqlmodel import select
 
 from app.api.deps import SessionDep
 from app.core.config import settings
@@ -733,8 +733,6 @@ def test_get_test_by_filter_description(
 def test_get_test_by_filter_start_time(
     client: TestClient, db: SessionDep, get_user_superadmin_token: dict[str, str]
 ) -> None:
-    db.execute(delete(Test))
-    db.commit()
     user = create_random_user(db)
 
     test_1 = Test(
@@ -743,7 +741,7 @@ def test_get_test_by_filter_start_time(
         created_by_id=user.id,
         link=random_lower_string(),
         no_of_random_questions=1,
-        start_time=datetime(2025, 4, 25, 10, 30),
+        start_time=datetime(2025, 7, 25, 10, 30),
     )
     test_2 = Test(
         name=random_lower_string(),
@@ -751,7 +749,7 @@ def test_get_test_by_filter_start_time(
         created_by_id=user.id,
         link=random_lower_string(),
         no_of_random_questions=1,
-        start_time=datetime(2025, 4, 27, 12, 30),
+        start_time=datetime(2025, 7, 27, 12, 30),
     )
     test_3 = Test(
         name=random_lower_string(),
@@ -759,7 +757,7 @@ def test_get_test_by_filter_start_time(
         created_by_id=user.id,
         link=random_lower_string(),
         no_of_random_questions=1,
-        start_time=datetime(2025, 4, 28, 15, 30),
+        start_time=datetime(2025, 7, 28, 15, 30),
     )
 
     test_4 = Test(
@@ -768,13 +766,13 @@ def test_get_test_by_filter_start_time(
         created_by_id=user.id,
         link=random_lower_string(),
         no_of_random_questions=1,
-        start_time=datetime(2025, 4, 28, 19, 30),
+        start_time=datetime(2025, 7, 28, 19, 30),
     )
     db.add_all([test_1, test_2, test_3, test_4])
     db.commit()
 
     response = client.get(
-        f"{settings.API_V1_STR}/test/?start_time_gte=2025-04-25T00:00:00Z",
+        f"{settings.API_V1_STR}/test/?start_time_gte=2025-07-25T00:00:00Z",
         headers=get_user_superadmin_token,
     )
 
@@ -784,7 +782,7 @@ def test_get_test_by_filter_start_time(
     assert len(data) == 4
 
     response = client.get(
-        f"{settings.API_V1_STR}/test/?start_time_gte=2025-04-27T00:00:00Z",
+        f"{settings.API_V1_STR}/test/?start_time_gte=2025-07-27T00:00:00Z",
         headers=get_user_superadmin_token,
     )
 
@@ -793,7 +791,7 @@ def test_get_test_by_filter_start_time(
     assert len(data) == 3
 
     response = client.get(
-        f"{settings.API_V1_STR}/test/?start_time_gte=2025-04-28T15:30:00Z",
+        f"{settings.API_V1_STR}/test/?start_time_gte=2025-07-28T15:30:00Z",
         headers=get_user_superadmin_token,
     )
 
@@ -802,7 +800,7 @@ def test_get_test_by_filter_start_time(
     assert len(data) == 2
 
     response = client.get(
-        f"{settings.API_V1_STR}/test/?start_time_gte=2025-04-28T15:30:59Z",
+        f"{settings.API_V1_STR}/test/?start_time_gte=2025-07-28T15:30:59Z",
         headers=get_user_superadmin_token,
     )
 
@@ -811,7 +809,7 @@ def test_get_test_by_filter_start_time(
     assert len(data) == 1
 
     response = client.get(
-        f"{settings.API_V1_STR}/test/?start_time_gte=2025-04-28T19:31:00Z",
+        f"{settings.API_V1_STR}/test/?start_time_gte=2025-07-28T19:31:00Z",
         headers=get_user_superadmin_token,
     )
 
@@ -820,7 +818,7 @@ def test_get_test_by_filter_start_time(
     assert len(data) == 0
 
     response = client.get(
-        f"{settings.API_V1_STR}/test/?start_time_gte=2025-04-24T00:00:00Z&start_time_lte=2025-04-26T00:00:00Z",
+        f"{settings.API_V1_STR}/test/?start_time_gte=2025-07-24T00:00:00Z&start_time_lte=2025-07-26T00:00:00Z",
         headers=get_user_superadmin_token,
     )
 
@@ -829,7 +827,7 @@ def test_get_test_by_filter_start_time(
     assert len(data) == 1
 
     response = client.get(
-        f"{settings.API_V1_STR}/test/?start_time_gte=2025-04-27T12:30:00Z&start_time_lte=2025-04-28T15:30:00Z",
+        f"{settings.API_V1_STR}/test/?start_time_gte=2025-07-27T12:30:00Z&start_time_lte=2025-07-28T15:30:00Z",
         headers=get_user_superadmin_token,
     )
 
@@ -838,7 +836,7 @@ def test_get_test_by_filter_start_time(
     assert len(data) == 2
 
     response = client.get(
-        f"{settings.API_V1_STR}/test/?start_time_lte=2025-04-28T15:30:00Z",
+        f"{settings.API_V1_STR}/test/?start_time_lte=2025-07-28T15:30:00Z&start_time_gte=2025-07-25T10:30:00Z",
         headers=get_user_superadmin_token,
     )
 
@@ -858,7 +856,7 @@ def test_get_test_by_filter_end_time(
         created_by_id=user.id,
         link=random_lower_string(),
         no_of_random_questions=1,
-        end_time=datetime(2025, 4, 25, 10, 30),
+        end_time=datetime(2025, 7, 25, 10, 30),
     )
     test_2 = Test(
         name=random_lower_string(),
@@ -866,7 +864,7 @@ def test_get_test_by_filter_end_time(
         created_by_id=user.id,
         link=random_lower_string(),
         no_of_random_questions=1,
-        end_time=datetime(2025, 4, 27, 12, 30),
+        end_time=datetime(2025, 7, 27, 12, 30),
     )
     test_3 = Test(
         name=random_lower_string(),
@@ -874,7 +872,7 @@ def test_get_test_by_filter_end_time(
         created_by_id=user.id,
         link=random_lower_string(),
         no_of_random_questions=1,
-        end_time=datetime(2025, 4, 28, 15, 30),
+        end_time=datetime(2025, 7, 28, 15, 30),
     )
 
     test_4 = Test(
@@ -883,13 +881,13 @@ def test_get_test_by_filter_end_time(
         created_by_id=user.id,
         link=random_lower_string(),
         no_of_random_questions=1,
-        end_time=datetime(2025, 4, 28, 19, 30),
+        end_time=datetime(2025, 7, 28, 19, 30),
     )
     db.add_all([test_1, test_2, test_3, test_4])
     db.commit()
 
     response = client.get(
-        f"{settings.API_V1_STR}/test/?end_time_gte=2025-04-25T00:00:00Z",
+        f"{settings.API_V1_STR}/test/?end_time_gte=2025-07-25T00:00:00Z",
         headers=get_user_superadmin_token,
     )
 
@@ -898,7 +896,7 @@ def test_get_test_by_filter_end_time(
     assert len(data) == 4
 
     response = client.get(
-        f"{settings.API_V1_STR}/test/?end_time_gte=2025-04-27T00:00:00Z",
+        f"{settings.API_V1_STR}/test/?end_time_gte=2025-07-27T00:00:00Z",
         headers=get_user_superadmin_token,
     )
 
@@ -907,7 +905,7 @@ def test_get_test_by_filter_end_time(
     assert len(data) == 3
 
     response = client.get(
-        f"{settings.API_V1_STR}/test/?end_time_gte=2025-04-28T15:30:00Z",
+        f"{settings.API_V1_STR}/test/?end_time_gte=2025-07-28T15:30:00Z",
         headers=get_user_superadmin_token,
     )
 
@@ -916,7 +914,7 @@ def test_get_test_by_filter_end_time(
     assert len(data) == 2
 
     response = client.get(
-        f"{settings.API_V1_STR}/test/?end_time_gte=2025-04-28T15:30:59Z",
+        f"{settings.API_V1_STR}/test/?end_time_gte=2025-07-28T15:30:59Z",
         headers=get_user_superadmin_token,
     )
 
@@ -925,7 +923,7 @@ def test_get_test_by_filter_end_time(
     assert len(data) == 1
 
     response = client.get(
-        f"{settings.API_V1_STR}/test/?end_time_gte=2025-04-28T19:31:00Z",
+        f"{settings.API_V1_STR}/test/?end_time_gte=2025-07-28T19:31:00Z",
         headers=get_user_superadmin_token,
     )
 
@@ -934,7 +932,7 @@ def test_get_test_by_filter_end_time(
     assert len(data) == 0
 
     response = client.get(
-        f"{settings.API_V1_STR}/test/?end_time_gte=2025-04-24T00:00:00Z&end_time_lte=2025-04-26T00:00:00Z",
+        f"{settings.API_V1_STR}/test/?end_time_gte=2025-07-24T00:00:00Z&end_time_lte=2025-07-26T00:00:00Z",
         headers=get_user_superadmin_token,
     )
 
@@ -943,7 +941,7 @@ def test_get_test_by_filter_end_time(
     assert len(data) == 1
 
     response = client.get(
-        f"{settings.API_V1_STR}/test/?end_time_gte=2025-04-27T12:30:00Z&end_time_lte=2025-04-28T15:30:00Z",
+        f"{settings.API_V1_STR}/test/?end_time_gte=2025-07-27T12:30:00Z&end_time_lte=2025-07-28T15:30:00Z",
         headers=get_user_superadmin_token,
     )
 
@@ -952,7 +950,7 @@ def test_get_test_by_filter_end_time(
     assert len(data) == 2
 
     response = client.get(
-        f"{settings.API_V1_STR}/test/?end_time_lte=2025-04-28T15:30:00Z",
+        f"{settings.API_V1_STR}/test/?end_time_lte=2025-07-28T15:30:00Z&end_time_lte=2025-07-25T10:30:00Z",
         headers=get_user_superadmin_token,
     )
 
@@ -2270,3 +2268,96 @@ def test_get_public_test_info_deleted(client: TestClient, db: SessionDep) -> Non
     response = client.get(f"{settings.API_V1_STR}/test/public/{test.link}")
     assert response.status_code == 404
     assert "Test not found or not active" in response.json()["detail"]
+
+
+def test_get_time_before_test_start_public(client: TestClient, db: SessionDep) -> None:
+    future_start_time = datetime.now() + timedelta(minutes=10)  # 10 minutes from now
+    test = Test(
+        name="Public Start Timer Test",
+        link="public-test-uuid",
+        is_active=True,
+        is_deleted=False,
+        start_time=future_start_time,
+        created_by_id=create_random_user(db).id,
+    )
+    db.add(test)
+    db.commit()
+    db.refresh(test)
+    response = client.get(f"{settings.API_V1_STR}/test/public/time_left/{test.link}")
+    assert response.status_code == 200
+    data = response.json()
+    assert "time_left_seconds" in data
+    assert data["time_left_seconds"].isdigit()
+    time_left = int(data["time_left_seconds"])
+    assert 590 <= time_left <= 600
+
+
+def test_public_timer_when_test_already_started(
+    client: TestClient, db: SessionDep
+) -> None:
+    test = Test(
+        name="Public Start Timer Test",
+        link="public-test-uuid",
+        is_active=True,
+        is_deleted=False,
+        start_time=datetime.now() - timedelta(minutes=10),
+        end_time=datetime.now() + timedelta(days=1),
+        created_by_id=create_random_user(db).id,
+    )
+    db.add(test)
+    db.commit()
+    db.refresh(test)
+    response = client.get(f"{settings.API_V1_STR}/test/public/time_left/{test.link}")
+    assert response.status_code == 200
+    data = response.json()
+
+    assert "time_left" in data
+    assert data["time_left"] == "0"
+
+
+def test_public_timer_test_not_found_or_not_active(
+    client: TestClient, db: SessionDep
+) -> None:
+    response = client.get(
+        f"{settings.API_V1_STR}/test/public/time_left/nonexistent-test-link"
+    )
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Test not found or not active"
+    user = create_random_user(db)
+    deleted_test = Test(
+        name="Deleted Test",
+        link="deleted-test-link",
+        start_time=datetime.now() + timedelta(minutes=10),
+        end_time=datetime.now() + timedelta(hours=2),
+        time_limit=60,
+        is_active=True,
+        is_deleted=True,  # Marked as deleted
+        created_by_id=user.id,
+    )
+    db.add(deleted_test)
+    db.commit()
+    response = client.get(
+        f"{settings.API_V1_STR}/test/public/time_left/{deleted_test.link}"
+    )
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Test not found or not active"
+
+
+def test_public_timer_returns_zero_if_start_time_none(
+    client: TestClient, db: SessionDep
+) -> None:
+    test = Test(
+        name="Test with no start time",
+        link="test-no-start-time",
+        is_active=True,
+        is_deleted=False,
+        start_time=None,  # This is the key for this test
+        created_by_id=create_random_user(db).id,
+    )
+    db.add(test)
+    db.commit()
+    db.refresh(test)
+    response = client.get(f"{settings.API_V1_STR}/test/public/time_left/{test.link}")
+    assert response.status_code == 200
+    data = response.json()
+    assert data == {"time_left": "0"}

--- a/backend/app/tests/api/routes/test_test.py
+++ b/backend/app/tests/api/routes/test_test.py
@@ -6,6 +6,7 @@ from fastapi.testclient import TestClient
 from sqlmodel import select
 
 from app.api.deps import SessionDep
+from app.api.routes.utils import get_current_time
 from app.core.config import settings
 from app.models import (
     Country,
@@ -21,7 +22,6 @@ from app.models import (
     TestTag,
 )
 from app.models.question import QuestionType
-from app.models.utils import get_current_time
 from app.tests.utils.location import create_random_state
 from app.tests.utils.question_revisions import create_random_question_revision
 from app.tests.utils.tag import create_random_tag

--- a/backend/app/tests/api/routes/test_test.py
+++ b/backend/app/tests/api/routes/test_test.py
@@ -950,7 +950,7 @@ def test_get_test_by_filter_end_time(
     assert len(data) == 2
 
     response = client.get(
-        f"{settings.API_V1_STR}/test/?end_time_lte=2025-07-28T15:30:00Z&end_time_lte=2025-07-25T10:30:00Z",
+        f"{settings.API_V1_STR}/test/?end_time_lte=2025-07-28T15:30:00Z&end_time_gte=2025-07-25T10:30:00Z",
         headers=get_user_superadmin_token,
     )
 
@@ -2300,7 +2300,7 @@ def test_public_timer_when_test_already_started(
         link="public-test-uuid",
         is_active=True,
         is_deleted=False,
-        start_time=datetime.now() - timedelta(minutes=10),
+        start_time=datetime.now() - timedelta(minutes=20),
         end_time=datetime.now() + timedelta(days=1),
         created_by_id=create_random_user(db).id,
     )
@@ -2311,8 +2311,8 @@ def test_public_timer_when_test_already_started(
     assert response.status_code == 200
     data = response.json()
 
-    assert "time_left" in data
-    assert data["time_left"] == "0"
+    assert "time_left_seconds" in data
+    assert data["time_left_seconds"] == "0"
 
 
 def test_public_timer_test_not_found_or_not_active(
@@ -2360,4 +2360,4 @@ def test_public_timer_returns_zero_if_start_time_none(
     response = client.get(f"{settings.API_V1_STR}/test/public/time_left/{test.link}")
     assert response.status_code == 200
     data = response.json()
-    assert data == {"time_left": "0"}
+    assert data == {"time_left_seconds": "0"}

--- a/backend/app/tests/api/routes/test_test.py
+++ b/backend/app/tests/api/routes/test_test.py
@@ -2289,8 +2289,8 @@ def test_get_time_before_test_start_public(client: TestClient, db: SessionDep) -
     response = client.get(f"{settings.API_V1_STR}/test/public/time_left/{test.link}")
     assert response.status_code == 200
     data = response.json()
-    assert "time_left_seconds" in data
-    time_left = data["time_left_seconds"]
+    assert "time_left" in data
+    time_left = data["time_left"]
     assert isinstance(time_left, int)
     assert 590 <= time_left <= 600
 
@@ -2300,7 +2300,7 @@ def test_public_timer_when_test_already_started(
 ) -> None:
     test = Test(
         name="Public Start Timer Test",
-        link="public-test-uuid",
+        link="public-test-uuid1",
         is_active=True,
         is_deleted=False,
         start_time=datetime(2024, 5, 24, 9, 0, 0),
@@ -2310,11 +2310,13 @@ def test_public_timer_when_test_already_started(
     db.add(test)
     db.commit()
     db.refresh(test)
+    print("test link is ", test.link)
+    print("time of now:", get_current_time())
     response = client.get(f"{settings.API_V1_STR}/test/public/time_left/{test.link}")
     assert response.status_code == 200
     data = response.json()
-    assert "time_left_seconds" in data
-    assert data["time_left_seconds"] == 0
+    assert "time_left" in data
+    assert data["time_left"] == 0
 
 
 def test_public_timer_test_not_found_or_not_active(
@@ -2362,4 +2364,4 @@ def test_public_timer_returns_zero_if_start_time_none(
     response = client.get(f"{settings.API_V1_STR}/test/public/time_left/{test.link}")
     assert response.status_code == 200
     data = response.json()
-    assert data == {"time_left_seconds": None}
+    assert data == {"time_left": None}

--- a/backend/app/tests/api/routes/test_test.py
+++ b/backend/app/tests/api/routes/test_test.py
@@ -2300,7 +2300,7 @@ def test_public_timer_when_test_already_started(
         link="public-test-uuid",
         is_active=True,
         is_deleted=False,
-        start_time=datetime.now() - timedelta(minutes=20),
+        start_time=datetime(2024, 5, 24, 9, 0, 0),
         end_time=datetime.now() + timedelta(days=1),
         created_by_id=create_random_user(db).id,
     )
@@ -2310,7 +2310,6 @@ def test_public_timer_when_test_already_started(
     response = client.get(f"{settings.API_V1_STR}/test/public/time_left/{test.link}")
     assert response.status_code == 200
     data = response.json()
-
     assert "time_left_seconds" in data
     assert data["time_left_seconds"] == "0"
 

--- a/backend/app/tests/api/routes/test_test.py
+++ b/backend/app/tests/api/routes/test_test.py
@@ -733,7 +733,7 @@ def test_get_test_by_filter_description(
 def test_get_test_by_filter_start_time(
     client: TestClient, db: SessionDep, get_user_superadmin_token: dict[str, str]
 ) -> None:
-    db.exec(delete(Test))
+    db.execute(delete(Test))
     db.commit()
     user = create_random_user(db)
 

--- a/backend/app/tests/api/routes/test_test.py
+++ b/backend/app/tests/api/routes/test_test.py
@@ -3,7 +3,7 @@ from typing import Any
 
 from fastapi import status
 from fastapi.testclient import TestClient
-from sqlmodel import select
+from sqlmodel import delete, select
 
 from app.api.deps import SessionDep
 from app.core.config import settings
@@ -733,6 +733,8 @@ def test_get_test_by_filter_description(
 def test_get_test_by_filter_start_time(
     client: TestClient, db: SessionDep, get_user_superadmin_token: dict[str, str]
 ) -> None:
+    db.exec(delete(Test))
+    db.commit()
     user = create_random_user(db)
 
     test_1 = Test(
@@ -778,6 +780,7 @@ def test_get_test_by_filter_start_time(
 
     assert response.status_code == 200
     data = response.json()
+
     assert len(data) == 4
 
     response = client.get(


### PR DESCRIPTION
fixes issue: #111  #112 

**This PR adds two new APIs to handle test timing:**

**1. Pre-Test Timer API (/pretest_timer/{candidate_test_id})**

- Returns the time (in minutes) left before the test starts.
- Returns an error if the test has already started.

**2. In-Test Timer API (/timer/{candidate_test_id})**

-  Returns the remaining time during the test.
-  Considers both the test’s time limit and end time.
- Returns the smaller of the two.
-  Returns an error if the time is over.





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added endpoints to display remaining time for a candidate's test and time left before a test starts.

- **Bug Fixes**
  - Improved error responses for missing or invalid candidate tests and timing data.

- **Tests**
  - Added comprehensive tests for candidate and public timer endpoints covering various timing and error scenarios.
  - Updated existing tests with new datetime values and enhanced query parameter handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->