### PR TITLE
Rename field to 'error_log' and add check for bulk uploads.

### DIFF
--- a/backend/app/api/routes/question.py
+++ b/backend/app/api/routes/question.py
@@ -1046,6 +1046,7 @@ async def upload_questions_csv(
         # Start processing rows
         questions_created = 0
         questions_failed = 0
+        failed_message = None
         failed_question_details = []
         tag_cache: dict[str, int] = {}  # Cache for tag lookups
         state_cache: dict[str, int] = {}  # Cache for state lookups
@@ -1304,17 +1305,14 @@ async def upload_questions_csv(
             csv_buffer.seek(0)
             csv_bytes = csv_buffer.getvalue().encode("utf-8")
             base64_csv = base64.b64encode(csv_bytes).decode("utf-8")
-            data_link = f"data:text/csv;base64,{base64_csv}"
-            failed_message = f"Download failed questions: {data_link}"
-        else:
-            failed_message = "No failed questions. No CSV generated."
+            failed_message = f"data:text/csv;base64,{base64_csv}"
 
         return BulkUploadQuestionsResponse(
             message=message,
             uploaded_questions=questions_created + questions_failed,
             success_questions=questions_created,
             failed_questions=questions_failed,
-            failed_question_details=failed_message,
+            error_log=failed_message,
         )
     except HTTPException:
         # Re-raise any HTTP exceptions we explicitly raised

--- a/backend/app/models/question.py
+++ b/backend/app/models/question.py
@@ -494,7 +494,7 @@ class BulkUploadQuestionsResponse(SQLModel):
     uploaded_questions: int
     success_questions: int
     failed_questions: int
-    failed_question_details: str | None
+    error_log: str | None
 
 
 # Force model rebuild to handle forward references

--- a/backend/app/tests/api/routes/test_question.py
+++ b/backend/app/tests/api/routes/test_question.py
@@ -1,6 +1,7 @@
 import base64
 import csv
 import io
+from contextlib import suppress
 from datetime import datetime, timedelta, timezone
 
 import pytest
@@ -1448,7 +1449,7 @@ What is the highest mountain?,Everest,K2,Denali,Kilimanjaro,A,Test Tag Type:Geog
         # Cleanup
         import os
 
-        if os.path.exists(temp_file_path):
+        with suppress(FileNotFoundError):
             os.unlink(temp_file_path)
 
 
@@ -3857,5 +3858,5 @@ Which planet is known as the Red Planet?,Earth,Mars,Jupiter,Venus,D,ABCD,Math,Pu
     finally:
         import os
 
-        if os.path.exists(temp_file_path):
+        with suppress(FileNotFoundError):
             os.unlink(temp_file_path)


### PR DESCRIPTION
Fixes issue: #187 ,#178
## Summary

- Renamed failed_question_details field to error_log
- error_log now stores only a base64 string or None
- Added test cases for validating file template before bulk question upload


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for bulk CSV question uploads by providing a base64-encoded CSV error log in the response with a clearer field name.

* **Tests**
  * Added new tests to verify bulk upload behavior with CSV files missing required columns or containing extra columns.
  * Updated existing tests to check for the renamed error log field in the response.
  * Enhanced test cleanup robustness by handling file deletion more gracefully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->