### PR TITLE
Add validation for single-choice questions to ensure only one correct…

### DIFF
--- a/backend/app/models/question.py
+++ b/backend/app/models/question.py
@@ -123,6 +123,29 @@ class QuestionBase(SQLModel):
         nullable=False,
         description="Type of question (single-choice, multi-choice, etc.)",
     )
+
+    @model_validator(mode="after")
+    def validate_correct_answers(self) -> "QuestionBase":
+        if self.question_type == QuestionType.single_choice:
+            if (
+                not isinstance(self.correct_answer, list)
+                or len(self.correct_answer) != 1
+            ):
+                raise ValueError(
+                    "Single-choice questions must have exactly one correct answer."
+                )
+
+        elif self.question_type == QuestionType.multi_choice:
+            if (
+                not isinstance(self.correct_answer, list)
+                or len(self.correct_answer) < 1
+            ):
+                raise ValueError(
+                    "Multi-choice questions must have at least one correct answer."
+                )
+
+        return self
+
     options: list[Option] | None = Field(
         sa_type=JSON,
         default=None,

--- a/backend/app/tests/api/routes/test_candidate.py
+++ b/backend/app/tests/api/routes/test_candidate.py
@@ -1848,7 +1848,7 @@ def test_get_test_result(
     candidate_test_answer = CandidateTestAnswer(
         candidate_test_id=candidate_test.id,
         question_revision_id=questions[0].id,
-        response=1,
+        response=2,
         visited=True,
         time_spent=30,
     )

--- a/backend/app/tests/utils/question_revisions.py
+++ b/backend/app/tests/utils/question_revisions.py
@@ -48,6 +48,7 @@ def create_random_question_revision(
         name=random_lower_string(),
         description=random_lower_string(),
         created_by_id=user.id,
+        correct_answer=[1],
         organization_id=organization.id,
     )
     session.add(question_revision)


### PR DESCRIPTION

Fixes issue: #195 
## Summary

- Added validation logic to ensure that single-choice questions  have exactly one correct answer.
- If more than one ID is passed in correct_answer, a 422 validation error is returned.