### PR TITLE
Update DistrictPublic model to include full state details

### DIFF
--- a/backend/app/api/routes/location.py
+++ b/backend/app/api/routes/location.py
@@ -240,7 +240,7 @@ def get_district(
     is_active: bool | None = None,
     state: int | None = None,
 ) -> Sequence[District]:
-    query = select(District)
+    query = select(District, State).join(State).where(District.state_id == State.id)
 
     if is_active is not None:
         query = query.where(District.is_active == is_active)
@@ -253,8 +253,12 @@ def get_district(
 
     # Apply apgination
     query = query.offset(skip).limit(limit)
+    results = session.exec(query).all()
 
-    districts = session.exec(query).all()
+    districts = []
+    for district, state_obj in results:
+        district.state = state_obj
+        districts.append(district)
 
     return districts
 

--- a/backend/app/models/location.py
+++ b/backend/app/models/location.py
@@ -93,7 +93,6 @@ class StateUpdate(StateBase):
 
 class DistrictBase(SQLModel):
     name: str = Field(nullable=False, index=True)
-    state_id: int = Field(foreign_key="state.id", nullable=False, ondelete="CASCADE")
     is_active: bool = Field(default=True)
 
 
@@ -113,20 +112,22 @@ class District(DistrictBase, table=True):
     tests: list["Test"] | None = Relationship(
         back_populates="districts", link_model=TestDistrict
     )
+    state_id: int = Field(foreign_key="state.id", nullable=False, ondelete="CASCADE")
 
 
 class DistrictPublic(DistrictBase):
     id: int
     created_date: datetime
     modified_date: datetime
+    state: State
 
 
 class DistrictCreate(DistrictBase):
-    pass
+    state_id: int
 
 
 class DistrictUpdate(DistrictBase):
-    pass
+    state_id: int
 
 
 # -----Models for District-----

--- a/backend/app/models/location.py
+++ b/backend/app/models/location.py
@@ -103,6 +103,7 @@ class District(DistrictBase, table=True):
         default_factory=get_timezone_aware_now,
         sa_column_kwargs={"onupdate": get_timezone_aware_now},
     )
+    state_id: int = Field(foreign_key="state.id", nullable=False, ondelete="CASCADE")
     state: State | None = Relationship(back_populates="districts")
     blocks: list["Block"] | None = Relationship(back_populates="district")
     question_locations: list["QuestionLocation"] = Relationship(
@@ -112,7 +113,6 @@ class District(DistrictBase, table=True):
     tests: list["Test"] | None = Relationship(
         back_populates="districts", link_model=TestDistrict
     )
-    state_id: int = Field(foreign_key="state.id", nullable=False, ondelete="CASCADE")
 
 
 class DistrictPublic(DistrictBase):

--- a/backend/app/models/location.py
+++ b/backend/app/models/location.py
@@ -119,7 +119,7 @@ class DistrictPublic(DistrictBase):
     id: int
     created_date: datetime
     modified_date: datetime
-    state: State
+    state: StatePublic
 
 
 class DistrictCreate(DistrictBase):

--- a/backend/app/tests/api/routes/test_location.py
+++ b/backend/app/tests/api/routes/test_location.py
@@ -397,7 +397,8 @@ def test_create_district(
     data = response.json()
     assert response.status_code == 200
     assert data["name"] == district_name
-    assert data["state_id"] == kerala.id
+    assert data["state"]["id"] == kerala.id
+    assert data["state"]["name"] == kerala.name
 
 
 def test_get_district(
@@ -431,7 +432,7 @@ def test_get_district(
     assert any(item["name"] == thrissur.name for item in data)
     assert any(item["id"] == ernakulam.id for item in data)
     assert any(item["id"] == thrissur.id for item in data)
-    assert any(item["state_id"] == kerala.id for item in data)
+    assert any(item["state"]["id"] == kerala.id for item in data)
 
     response = client.get(
         f"{settings.API_V1_STR}/location/district/",
@@ -546,8 +547,8 @@ def test_get_district_by_id(
     assert response.status_code == 200
     assert data["name"] == ernakulam.name
     assert data["id"] == ernakulam.id
-    assert data["state_id"] == ernakulam.state_id
-    assert data["state_id"] == kerala.id
+    assert data["state"]["id"] == ernakulam.state_id
+    assert data["state"]["id"] == kerala.id
     response = client.get(
         f"{settings.API_V1_STR}/location/district/-1", headers=get_user_superadmin_token
     )
@@ -593,8 +594,8 @@ def test_update_district(
     data = response.json()
     assert data["name"] == updated_name
     assert data["id"] == ernakulam.id
-    assert data["state_id"] == andhra_pradesh.id
-    assert data["state_id"] != kerala.id
+    assert data["state"]["id"] == andhra_pradesh.id
+    assert data["state"]["id"] != kerala.id
 
     response = client.put(
         f"{settings.API_V1_STR}/location/district/-1",

--- a/backend/app/tests/api/routes/test_location.py
+++ b/backend/app/tests/api/routes/test_location.py
@@ -491,7 +491,7 @@ def test_get_district_by_name_filter(
         headers=get_user_superadmin_token,
     )
     data = response.json()
-    print("help", data)
+
     assert response.status_code == 200
     assert len(data) == 1
     assert data[0]["name"] == "North Zone Extension"
@@ -548,7 +548,7 @@ def test_get_district_by_id(
     assert data["name"] == ernakulam.name
     assert data["id"] == ernakulam.id
     assert data["state"]["id"] == ernakulam.state_id
-    assert data["state"]["id"] == kerala.id
+    assert data["state"]["name"] == kerala.name
     response = client.get(
         f"{settings.API_V1_STR}/location/district/-1", headers=get_user_superadmin_token
     )
@@ -595,6 +595,7 @@ def test_update_district(
     assert data["name"] == updated_name
     assert data["id"] == ernakulam.id
     assert data["state"]["id"] == andhra_pradesh.id
+    assert data["state"]["name"] == andhra_pradesh.name
     assert data["state"]["id"] != kerala.id
 
     response = client.put(


### PR DESCRIPTION
Fixes issue: #200 
## Summary
 when we get district data, it will also show full details about its state, not just the state ID.  
This makes it easier to see  info about the district and its state in one place.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - District responses now include a nested state object (id, name) instead of a flat state_id.
  - Creating and updating districts now require a state_id, making state association explicit.

- **Tests**
  - Updated tests to assert the nested state object in district responses and validate state on create/update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->