### PR TITLE
include Role and Organization details in User public model

### DIFF
--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -5,6 +5,8 @@ from pydantic import EmailStr
 from sqlmodel import Field, Relationship, SQLModel, UniqueConstraint
 
 from app.core.timezone import get_timezone_aware_now
+from app.models.organization import OrganizationPublic
+from app.models.role import Role
 
 if TYPE_CHECKING:
     from app.models import (
@@ -44,8 +46,6 @@ class UserBase(SQLModel):
         description="Enter Email Address",
     )
     phone: str = Field(max_length=255)
-    role_id: int = Field(foreign_key="role.id")
-    organization_id: int = Field(foreign_key="organization.id")
     created_by_id: int | None = Field(default=None, foreign_key="user.id")
     is_active: bool = Field(default=True)
 
@@ -62,6 +62,8 @@ class UserCreate(UserBase):
     state_ids: list[int] | None = Field(
         default=None, description="IDs of states to associate with the user"
     )
+    organization_id: int
+    role_id: int
 
 
 # Properties to receive via API on update, all are optional
@@ -69,6 +71,8 @@ class UserUpdate(UserBase):
     email: EmailStr | None = Field(default=None, max_length=255)  # type: ignore
     password: str | None = Field(default=None, min_length=8, max_length=40)
     state_ids: list[int] | None = None
+    organization_id: int | None = None
+    role_id: int | None = None
 
 
 class UserUpdateMe(SQLModel):
@@ -97,6 +101,8 @@ class User(UserBase, table=True):
     token: str | None = Field(default=None)
     refresh_token: str | None = Field(default=None)
     created_by_id: int | None = Field(default=None, foreign_key="user.id")
+    role_id: int = Field(foreign_key="role.id")
+    organization_id: int = Field(foreign_key="organization.id")
     tests: list["Test"] | None = Relationship(back_populates="created_by")
     candidates: list["Candidate"] = Relationship(back_populates="user")
     tag_types: list["TagType"] = Relationship(back_populates="created_by")
@@ -124,6 +130,8 @@ class UserPublic(UserBase):
     modified_date: datetime
     is_deleted: bool
     created_by_id: int | None
+    organization: OrganizationPublic | None = None
+    role: Role | None = None
     states: list["State"] | None = Field(
         default=None, description="states associated with this user"
     )

--- a/backend/app/tests/utils/user.py
+++ b/backend/app/tests/utils/user.py
@@ -126,4 +126,6 @@ def get_current_user_data(
     )
     assert response.status_code == 200, f"Failed to fetch user info: {response.text}"
     user_data = cast(dict[str, Any], response.json())
+    if isinstance(user_data.get("organization"), dict):
+        user_data["organization_id"] = user_data["organization"]["id"]
     return user_data


### PR DESCRIPTION
Fixes issue: #199 
## Summary

Updated the User public model to include role and organization details


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - User lists and profiles now include embedded role and organization details, scoped to the current user’s organization.
  - Creating a user now requires selecting a role and organization; updates allow changing these associations.

- **Tests**
  - API tests updated to expect nested role and organization objects instead of flat ID fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->