### PR TITLE
allow phone number update in PATCH /user/me API

### DIFF
--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -74,6 +74,7 @@ class UserUpdate(UserBase):
 class UserUpdateMe(SQLModel):
     full_name: str | None = Field(default=None, max_length=255)
     email: EmailStr | None = Field(default=None, max_length=255)
+    phone: str | None = Field(default=None, max_length=255)
 
 
 class UpdatePassword(SQLModel):


### PR DESCRIPTION
Fixes issue: #207 
## Summary
This PR enhances the PATCH /user/me API by allowing users to update their phone number in addition to their name and email.



