### PR TITLE
 Add support for new question types in the API

### DIFF
--- a/backend/app/alembic/versions/ae31b05eff57_add_numerical_decimal_to_questiontype_.py
+++ b/backend/app/alembic/versions/ae31b05eff57_add_numerical_decimal_to_questiontype_.py
@@ -1,0 +1,29 @@
+"""add numerical_decimal to questiontype enum
+
+Revision ID: ae31b05eff57
+Revises: b0a29fe32d37
+Create Date: 2025-08-25 18:28:54.069552
+
+"""
+from alembic import op
+import sqlalchemy as sa
+import sqlmodel.sql.sqltypes
+
+
+# revision identifiers, used by Alembic.
+revision = 'ae31b05eff57'
+down_revision = 'b0a29fe32d37'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("ALTER TYPE questiontype ADD VALUE IF NOT EXISTS 'numerical_decimal'")
+    op.execute("ALTER TYPE questiontype ADD VALUE IF NOT EXISTS 'matrix_matches'")
+    op.execute("ALTER TYPE questiontype ADD VALUE IF NOT EXISTS 'matrix_ratings'")
+    op.execute("ALTER TYPE questiontype ADD VALUE IF NOT EXISTS 'matrix_numbers'")
+    op.execute("ALTER TYPE questiontype ADD VALUE IF NOT EXISTS 'matrix_texts'")
+
+
+def downgrade():
+    pass

--- a/backend/app/models/question.py
+++ b/backend/app/models/question.py
@@ -27,6 +27,11 @@ class QuestionType(str, Enum):
     multi_choice = "multi-choice"
     subjective = "subjective"
     numerical_integer = "numerical-integer"
+    numerical_decimal = "numerical-decimal"
+    matrix_matches = "matrix-matches"
+    matrix_ratings = "matrix-ratings"
+    matrix_numbers = "matrix-numbers"
+    matrix_texts = "matrix-texts"
 
 
 # Simple structure classes - no SQLModel inheritance
@@ -79,7 +84,7 @@ class FailedQuestion(TypedDict):
 OptionDict = dict[str, Any]  # Consider using dict[str, Union[str, ImageDict]] later
 MarkingSchemeDict = dict[str, float]  # More specific than dict[str, Any]
 ImageDict = dict[str, Any]  # Consider using dict[str, Union[str, None]] later
-CorrectAnswerType = list[int] | list[str] | float | int | None
+CorrectAnswerType = list[int] | list[str] | float | int | str | dict[Any, Any] | None
 
 
 class QuestionBase(SQLModel):

--- a/backend/app/tests/api/routes/test_question.py
+++ b/backend/app/tests/api/routes/test_question.py
@@ -123,6 +123,99 @@ def test_create_question(
     ).all()
     assert len(question_tags) == 1
     assert question_tags[0].tag_id == tag_id
+    numeric_question_text = random_lower_string()
+    numeric_question_data = {
+        "organization_id": org_id,
+        "question_text": numeric_question_text,
+        "question_type": QuestionType.numerical_integer,
+        "correct_answer": 42,
+        "is_mandatory": True,
+    }
+
+    numeric_response = client.post(
+        f"{settings.API_V1_STR}/questions/",
+        json=numeric_question_data,
+        headers=get_user_superadmin_token,
+    )
+    numeric_data = numeric_response.json()
+
+    assert numeric_response.status_code == 200
+    assert numeric_data["question_text"] == numeric_question_text
+    assert numeric_data["organization_id"] == org_id
+    assert numeric_data["question_type"] == QuestionType.numerical_integer
+    assert numeric_data["options"] is None
+    assert numeric_data["correct_answer"] == 42
+    assert numeric_data["created_by_id"] == user_id
+
+    # 3. Subjective Question
+    question_data = {
+        "organization_id": org_id,
+        "question_text": random_lower_string(),
+        "question_type": QuestionType.subjective,
+        "correct_answer": "mumbai",
+    }
+    response = client.post(
+        f"{settings.API_V1_STR}/questions/",
+        json=question_data,
+        headers=get_user_superadmin_token,
+    )
+    data = response.json()
+    assert response.status_code == 200
+    assert data["question_type"] == QuestionType.subjective
+    assert data["correct_answer"] == "mumbai"
+
+    # 4. Numerical Decimal Question
+    question_data = {
+        "organization_id": org_id,
+        "question_text": random_lower_string(),
+        "question_type": QuestionType.numerical_decimal,
+        "correct_answer": 45.5,
+    }
+
+    response = client.post(
+        f"{settings.API_V1_STR}/questions/",
+        json=question_data,
+        headers=get_user_superadmin_token,
+    )
+    data = response.json()
+    assert response.status_code == 200
+    assert data["question_type"] == QuestionType.numerical_decimal
+    assert data["correct_answer"] == 45.5
+
+    # Matrix Matches Question
+    question_data = {
+        "organization_id": org_id,
+        "question_text": random_lower_string(),
+        "question_type": QuestionType.matrix_matches,
+        "options": None,
+        "correct_answer": {"row1": "col1"},
+    }
+    response = client.post(
+        f"{settings.API_V1_STR}/questions/",
+        json=question_data,
+        headers=get_user_superadmin_token,
+    )
+    data = response.json()
+    assert response.status_code == 200
+    assert data["question_type"] == QuestionType.matrix_matches
+
+    # Matrix Ratings Question
+    question_data = {
+        "organization_id": org_id,
+        "question_text": random_lower_string(),
+        "question_type": QuestionType.matrix_ratings,
+        "options": None,
+        "correct_answer": {"row1": "col1"},
+    }
+
+    response = client.post(
+        f"{settings.API_V1_STR}/questions/",
+        json=question_data,
+        headers=get_user_superadmin_token,
+    )
+    data = response.json()
+    assert response.status_code == 200
+    assert data["question_type"] == QuestionType.matrix_ratings
 
 
 def test_read_questions(


### PR DESCRIPTION
## Summary

Add new question types to the API

- [ ] Matrix of Matches
- [ ]   Matrix of Ratings
- [ ]   Matrix of Numbers
- [ ]   Matrix of Texts
- [ ]   Integer answers
- [ ]   Decimal answers
- [ ]   Text answers(subjective)

This PR works for numerical integer, decimal, and text answers (subjective). Other question types are not covered.