### PR TITLE
Ignore Deactivated Questions

### DIFF
--- a/backend/app/api/routes/candidate.py
+++ b/backend/app/api/routes/candidate.py
@@ -244,8 +244,13 @@ def start_test_for_candidate(
 
             question_ids_for_tag = session.exec(
                 select(Question.last_revision_id)
-                .join(QuestionTag)
-                .where(Question.id == QuestionTag.question_id)
+                .join(
+                    QuestionTag,
+                    and_(
+                        Question.id == QuestionTag.question_id,
+                        Question.is_active,
+                    ),
+                )
                 .where(QuestionTag.tag_id == tag_id)
                 .where(
                     not_(

--- a/backend/app/tests/api/routes/test_candidate.py
+++ b/backend/app/tests/api/routes/test_candidate.py
@@ -4777,6 +4777,9 @@ def test_start_test_skips_inactive_questions(
         db.add(qrev)
         db.commit()
         db.refresh(qrev)
+        question.last_revision_id = qrev.id
+        db.commit()
+        db.refresh(question)
 
         qt = QuestionTag(question_id=question.id, tag_id=tag.id)
         db.add(qt)


### PR DESCRIPTION
Fixes issue: #230 
## Summary

- Added condition to skip inactive questions during randomization.
- added test case to verify only active questions are picked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Tag-based randomized tests now exclude inactive questions, ensuring candidates receive only active, valid content and improving test integrity.

- Tests
  - Added automated tests to verify inactive questions are skipped during tag-based test generation, strengthening reliability of selection logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->