### PR TITLE
correctly handle password reset by user ID from token

### DIFF
--- a/backend/app/api/routes/login.py
+++ b/backend/app/api/routes/login.py
@@ -156,10 +156,14 @@ def reset_password(session: SessionDep, body: NewPassword) -> Message:
     """
     Reset password
     """
-    email = verify_password_reset_token(token=body.token)
-    if not email:
+    raw_user_id = verify_password_reset_token(token=body.token)
+    if not raw_user_id:
         raise HTTPException(status_code=400, detail="Invalid token")
-    user = crud.get_user_by_email(session=session, email=email)
+    try:
+        user_id = int(raw_user_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid token format")
+    user = crud.get_user_by_id(session=session, id=user_id)
     if not user:
         raise HTTPException(
             status_code=404,


### PR DESCRIPTION
Fixes issue: #185 
## Summary

Refactor /reset-password/ to use user ID from token, handle invalid token formats, and fetch user by ID before updating password. Fixes type mismatch errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Password reset now returns a clear error for invalid token formats and prevents unintended changes when tokens are malformed.
- Refactor
  - Improved password reset flow with stronger token validation for more reliable and secure resets.
- Tests
  - Added test for invalid token format behavior.
  - Updated password reset token generation and expiry handling in tests to match the new flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->