### PR TITLE
prevent state-admin creation without state

### DIFF
--- a/backend/app/api/routes/users.py
+++ b/backend/app/api/routes/users.py
@@ -95,9 +95,14 @@ def create_user(
         session=session, user_create=user_in, created_by_id=current_user.id
     )
     states = None
-    role = session.exec(select(Role).where(Role.id == user.role_id)).first()
+    role = session.get(Role, user.role_id)
 
-    if role and role.name == "state_admin" and user_in.state_ids:
+    if role and role.name == "state_admin":
+        if not user_in.state_ids:
+            raise HTTPException(
+                status_code=400,
+                detail="A state-admin must be assigned at least one state.",
+            )
         existing_states = session.exec(
             select(State).where(col(State.id).in_(user_in.state_ids))
         ).all()

--- a/backend/app/tests/api/routes/test_user.py
+++ b/backend/app/tests/api/routes/test_user.py
@@ -885,10 +885,9 @@ def test_create_state_admin_without_state_id(
             headers=superuser_token_headers,
             json=data,
         )
-        assert response.status_code == 200
+        assert response.status_code == 400
         data = response.json()
-        assert "states" in data
-        assert data["states"] is None
+        assert data["detail"] == "A state-admin must be assigned at least one state."
 
 
 def test_create_state_admin_with_state_id(


### PR DESCRIPTION
Fixes issue:  #246 
## Summary
Update state mapping for users

- A state-user cannot be created without mapping to a state.
- A test-admin , if created by a state-admin, should be auto mapped to the location of the state-admin
- A test-admin, if created any other user (a user without a state) , can be optionally be mapped to maximum one state.