### PR TITLE
Auto-map created tests to state-admin's location

### DIFF
--- a/backend/app/api/routes/test.py
+++ b/backend/app/api/routes/test.py
@@ -243,13 +243,18 @@ def create_test(
         session.add_all(question_links)
         session.commit()
 
-    if test_create.state_ids:
-        state_ids = test_create.state_ids
-        state_links = [
-            TestState(test_id=test.id, state_id=state_id) for state_id in state_ids
-        ]
-        session.add_all(state_links)
-        session.commit()
+    state_ids_to_assign = (
+        [state.id for state in current_user.states if state.id is not None]
+        if current_user.role.name == "state_admin" and current_user.states
+        else test_create.state_ids or []
+    )
+
+    if state_ids_to_assign:
+        session.add_all(
+            TestState(test_id=test.id, state_id=state_id)
+            for state_id in state_ids_to_assign
+        )
+    session.commit()
     if test_create.district_ids:
         district_ids = test_create.district_ids
         district_links = [

--- a/backend/app/tests/api/routes/test_test.py
+++ b/backend/app/tests/api/routes/test_test.py
@@ -28,6 +28,7 @@ from app.models.candidate import Candidate, CandidateTest, CandidateTestAnswer
 from app.models.entity import Entity, EntityType
 from app.models.location import Block, District
 from app.models.question import QuestionType
+from app.models.role import Role
 from app.models.test import TestDistrict
 from app.tests.utils.location import create_random_state
 from app.tests.utils.organization import (
@@ -35,8 +36,16 @@ from app.tests.utils.organization import (
 )
 from app.tests.utils.question_revisions import create_random_question_revision
 from app.tests.utils.tag import create_random_tag
-from app.tests.utils.user import create_random_user, get_current_user_data
-from app.tests.utils.utils import assert_paginated_response, random_lower_string
+from app.tests.utils.user import (
+    authentication_token_from_email,
+    create_random_user,
+    get_current_user_data,
+)
+from app.tests.utils.utils import (
+    assert_paginated_response,
+    random_email,
+    random_lower_string,
+)
 
 
 def setup_data(
@@ -388,6 +397,69 @@ def test_create_test(
     ).all()
 
     assert test_question_link == []
+
+
+def test_create_test_state_admin_auto_map(
+    client: TestClient, db: SessionDep, get_user_superadmin_token: dict[str, str]
+) -> None:
+    state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
+    assert state_admin_role
+
+    country = Country(name=random_lower_string(), is_active=True)
+    db.add(country)
+    db.commit()
+    db.refresh(country)
+
+    state = State(name=random_lower_string(), is_active=True, country_id=country.id)
+    db.add(state)
+    db.commit()
+    db.refresh(state)
+
+    org = create_random_organization(db)
+    email = random_email()
+    state_admin_payload = {
+        "email": email,
+        "password": random_lower_string(),
+        "phone": random_lower_string(),
+        "full_name": random_lower_string(),
+        "role_id": state_admin_role.id,
+        "organization_id": org.id,
+        "state_ids": [state.id],
+    }
+    resp = client.post(
+        f"{settings.API_V1_STR}/users/",
+        json=state_admin_payload,
+        headers=get_user_superadmin_token,
+    )
+    assert resp.status_code == 200
+    token_headers = authentication_token_from_email(client=client, email=email, db=db)
+
+    payload = {
+        "name": random_lower_string(),
+        "description": random_lower_string(),
+        "time_limit": 5,
+        "marks": 10,
+        "completion_message": "Congrats!",
+        "start_instructions": "Follow instructions",
+        "link": random_lower_string(),
+        "no_of_attempts": 1,
+        "shuffle": False,
+        "random_questions": False,
+        "no_of_random_questions": 2,
+        "question_pagination": 1,
+        "is_template": False,
+    }
+    response = client.post(
+        f"{settings.API_V1_STR}/test/",
+        json=payload,
+        headers=token_headers,
+    )
+    data = response.json()
+    assert response.status_code == 200
+
+    assert "states" in data
+    assert len(data["states"]) == 1
+    assert data["states"][0]["id"] == state.id
 
 
 def test_create_test_with_random_tag_count(


### PR DESCRIPTION
Fixes issue: #247 
This PR updates

- Auto-map tests, questions, and users to the state of the current state-admin.
- No need for the client to provide state information.
- State-admins can only create other state-admins or test-admins in the same state.